### PR TITLE
Scope cu118-pinned PyTorch packages to Windows in requirements.txt

### DIFF
--- a/requirements-CUDA128.txt
+++ b/requirements-CUDA128.txt
@@ -1,7 +1,12 @@
 chess
 matplotlib
 --extra-index-url https://download.pytorch.org/whl/cu128
-torch
+torch==2.7.1+cu128; platform_system == "Windows"
+torchvision==0.22.1+cu128; platform_system == "Windows"
+torchaudio==2.7.1+cu128; platform_system == "Windows"
+torch; platform_system != "Windows"
+torchvision; platform_system != "Windows"
+torchaudio; platform_system != "Windows"
 pytorch-lightning==1.9.5
 tensorboard
 cupy-cuda12x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
 chess
 matplotlib
 --extra-index-url https://download.pytorch.org/whl/cu118
-torch
+torch==2.7.1+cu118; platform_system == "Windows"
+torchvision==0.22.1+cu118; platform_system == "Windows"
+torchaudio==2.7.1+cu118; platform_system == "Windows"
+torch; platform_system != "Windows"
+torchvision; platform_system != "Windows"
+torchaudio; platform_system != "Windows"
 pytorch-lightning==1.9.5
 tensorboard
 cupy-cuda11x


### PR DESCRIPTION
### Motivation
- On Windows `pip install` was pulling a non-cu118 `torch` wheel which resulted in missing CUDA 11.8-compatible builds.
- Non-Windows environments were functioning with unpinned `torch` packages and should not be forced to cu118 pins.
- Provide a platform-specific installation experience so Windows users get cu118 wheels while other platforms remain unchanged.

### Description
- Updated `requirements.txt` to pin `torch==2.7.1+cu118`, `torchvision==0.22.1+cu118`, and `torchaudio==2.7.1+cu118` only when `platform_system == "Windows"`.
- Added unpinned `torch`, `torchvision`, and `torchaudio` entries for non-Windows platforms using `platform_system != "Windows"`.
- Retained the `--extra-index-url https://download.pytorch.org/whl/cu118` entry so Windows can find cu118 wheels.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fdacfb4883229167945eeae3c523)