### PR TITLE
Trainer: add potion zones/cooldowns to HalfKAv2 features

### DIFF
--- a/halfka_v2.py
+++ b/halfka_v2.py
@@ -10,9 +10,19 @@ NUM_SQ = variant.SQUARES
 NUM_KSQ = variant.KING_SQUARES
 NUM_PT_REAL = variant.PIECES - (NUM_KSQ != 1)
 NUM_PT_VIRTUAL = variant.PIECES
-NUM_PLANES_REAL = NUM_SQ * NUM_PT_REAL + (NUM_PT_REAL - (NUM_KSQ != 1)) * variant.POCKETS
-NUM_PLANES_VIRTUAL = NUM_SQ * NUM_PT_VIRTUAL + (NUM_PT_REAL - (NUM_KSQ != 1)) * variant.POCKETS
+HAS_POTIONS = getattr(variant, "HAS_POTIONS", False)
+POTION_TYPE_NB = 2
+POTION_COOLDOWN_BITS = 16
+POTION_ZONE_PLANES = POTION_TYPE_NB * 2 if HAS_POTIONS else 0
+POTION_ZONE_FEATURES = POTION_ZONE_PLANES * NUM_SQ
+POTION_COOLDOWN_FEATURES = POTION_TYPE_NB * 2 * POTION_COOLDOWN_BITS if HAS_POTIONS else 0
+NUM_PLANES_BASE = NUM_SQ * NUM_PT_REAL + (NUM_PT_REAL - (NUM_KSQ != 1)) * variant.POCKETS
+POTION_ZONE_OFFSET = NUM_PLANES_BASE
+POTION_COOLDOWN_OFFSET = POTION_ZONE_OFFSET + POTION_ZONE_FEATURES
+NUM_PLANES_REAL = NUM_PLANES_BASE + POTION_ZONE_FEATURES + POTION_COOLDOWN_FEATURES
+NUM_PLANES_VIRTUAL = NUM_SQ * NUM_PT_VIRTUAL + (NUM_PT_REAL - (NUM_KSQ != 1)) * variant.POCKETS + POTION_ZONE_FEATURES + POTION_COOLDOWN_FEATURES
 NUM_INPUTS = NUM_PLANES_REAL * NUM_KSQ
+FEATURE_HASH = 0x7c2d4f9e if HAS_POTIONS else 0x5f234cb8
 
 def orient(is_white_pov: bool, sq: int):
   return sq % variant.FILES + (variant.RANKS - 1 - (sq // variant.FILES)) * variant.FILES if not is_white_pov else sq
@@ -27,6 +37,14 @@ def halfka_idx(is_white_pov: bool, king_sq: int, sq: int, piece_type: int, color
 def halfka_hand_idx(is_white_pov: bool, king_sq: int, handCount: int, piece_type: int, color: bool):
   p_idx = (piece_type - 1) * 2 + (color != is_white_pov)
   return handCount + p_idx * variant.POCKETS + NUM_SQ * NUM_PT_REAL + king_sq * NUM_PLANES_REAL
+
+def halfka_potion_zone_idx(is_white_pov: bool, king_sq: int, sq: int, potion_type: int, owner_color: bool):
+  potion_idx = potion_type + POTION_TYPE_NB * (0 if owner_color == chess.WHITE else 1)
+  return orient(is_white_pov, sq) + POTION_ZONE_OFFSET + potion_idx * NUM_SQ + king_sq * NUM_PLANES_REAL
+
+def halfka_potion_cooldown_idx(is_white_pov: bool, king_sq: int, bit: int, potion_type: int, owner_color: bool):
+  potion_idx = potion_type + POTION_TYPE_NB * (0 if owner_color == chess.WHITE else 1)
+  return bit + POTION_COOLDOWN_OFFSET + potion_idx * POTION_COOLDOWN_BITS + king_sq * NUM_PLANES_REAL
 
 def map_king(sq: int):
   # palace squares for Xiangi/Janggi
@@ -59,13 +77,26 @@ def halfka_psqts():
 
 class Features(FeatureBlock):
   def __init__(self):
-    super(Features, self).__init__('HalfKAv2', 0x5f234cb8, OrderedDict([('HalfKAv2', NUM_PLANES_REAL * NUM_KSQ)]))
+    super(Features, self).__init__('HalfKAv2', FEATURE_HASH, OrderedDict([('HalfKAv2', NUM_PLANES_REAL * NUM_KSQ)]))
 
   def get_active_features(self, board: chess.Board):
     def piece_features(turn):
       indices = torch.zeros(NUM_PLANES_REAL * NUM_KSQ)
+      ksq = orient(turn, board.king(turn))
       for sq, p in board.piece_map().items():
-        indices[halfka_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
+        indices[halfka_idx(turn, ksq, sq, p)] = 1.0
+      if HAS_POTIONS:
+        potion_zones = getattr(board, "potion_zones", None)
+        if isinstance(potion_zones, dict):
+          for (owner_color, potion_type), squares in potion_zones.items():
+            for sq in squares:
+              indices[halfka_potion_zone_idx(turn, ksq, sq, potion_type, owner_color)] = 1.0
+        potion_cooldowns = getattr(board, "potion_cooldowns", None)
+        if isinstance(potion_cooldowns, dict):
+          for (owner_color, potion_type), cooldown in potion_cooldowns.items():
+            for bit in range(POTION_COOLDOWN_BITS):
+              if cooldown & (1 << bit):
+                indices[halfka_potion_cooldown_idx(turn, ksq, bit, potion_type, owner_color)] = 1.0
       return indices
     return (piece_features(chess.WHITE), piece_features(chess.BLACK))
 
@@ -74,7 +105,7 @@ class Features(FeatureBlock):
 
 class FactorizedFeatures(FeatureBlock):
   def __init__(self):
-    super(FactorizedFeatures, self).__init__('HalfKAv2^', 0x5f234cb8, OrderedDict([('HalfKAv2', NUM_PLANES_REAL * NUM_KSQ), ('A', NUM_PLANES_VIRTUAL)]))
+    super(FactorizedFeatures, self).__init__('HalfKAv2^', FEATURE_HASH, OrderedDict([('HalfKAv2', NUM_PLANES_REAL * NUM_KSQ), ('A', NUM_PLANES_VIRTUAL)]))
 
   def get_active_features(self, board: chess.Board):
     raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')

--- a/halfka_v2.py
+++ b/halfka_v2.py
@@ -22,7 +22,7 @@ POTION_COOLDOWN_OFFSET = POTION_ZONE_OFFSET + POTION_ZONE_FEATURES
 NUM_PLANES_REAL = NUM_PLANES_BASE + POTION_ZONE_FEATURES + POTION_COOLDOWN_FEATURES
 NUM_PLANES_VIRTUAL = NUM_SQ * NUM_PT_VIRTUAL + (NUM_PT_REAL - (NUM_KSQ != 1)) * variant.POCKETS + POTION_ZONE_FEATURES + POTION_COOLDOWN_FEATURES
 NUM_INPUTS = NUM_PLANES_REAL * NUM_KSQ
-FEATURE_HASH = 0x7c2d4f9e if HAS_POTIONS else 0x5f234cb8
+FEATURE_HASH = 0x6a8f3c12 if HAS_POTIONS else 0x5f234cb8
 
 def orient(is_white_pov: bool, sq: int):
   return sq % variant.FILES + (variant.RANKS - 1 - (sq // variant.FILES)) * variant.FILES if not is_white_pov else sq
@@ -39,11 +39,13 @@ def halfka_hand_idx(is_white_pov: bool, king_sq: int, handCount: int, piece_type
   return handCount + p_idx * variant.POCKETS + NUM_SQ * NUM_PT_REAL + king_sq * NUM_PLANES_REAL
 
 def halfka_potion_zone_idx(is_white_pov: bool, king_sq: int, sq: int, potion_type: int, owner_color: bool):
-  potion_idx = potion_type + POTION_TYPE_NB * (0 if owner_color == chess.WHITE else 1)
+  pov_color = chess.WHITE if is_white_pov else chess.BLACK
+  potion_idx = potion_type + POTION_TYPE_NB * (0 if owner_color == pov_color else 1)
   return orient(is_white_pov, sq) + POTION_ZONE_OFFSET + potion_idx * NUM_SQ + king_sq * NUM_PLANES_REAL
 
 def halfka_potion_cooldown_idx(is_white_pov: bool, king_sq: int, bit: int, potion_type: int, owner_color: bool):
-  potion_idx = potion_type + POTION_TYPE_NB * (0 if owner_color == chess.WHITE else 1)
+  pov_color = chess.WHITE if is_white_pov else chess.BLACK
+  potion_idx = potion_type + POTION_TYPE_NB * (0 if owner_color == pov_color else 1)
   return bit + POTION_COOLDOWN_OFFSET + potion_idx * POTION_COOLDOWN_BITS + king_sq * NUM_PLANES_REAL
 
 def map_king(sq: int):

--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -58,6 +58,10 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 static_assert(DATA_SIZE % 8 == 0);
 
+#ifndef HAS_POTIONS
+#define HAS_POTIONS 0
+#endif
+
 namespace chess
 {
     #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
@@ -120,6 +124,9 @@ namespace chess
         None,
         NB
     };
+
+    constexpr int POTION_TYPE_NB = 2;
+    constexpr int POTION_COOLDOWN_BITS = 16;
 
     constexpr Color color_of(Piece p) {
         return p >= Piece::Black ? Color::Black : Color::White;
@@ -359,7 +366,9 @@ namespace chess
             m_epSquare(Square::NB),
             m_castlingRights(CastlingRights::All),
             m_rule50Counter(0),
-            m_ply(0)
+            m_ply(0),
+            m_potionZones{},
+            m_potionCooldowns{}
         {
         }
 
@@ -369,7 +378,9 @@ namespace chess
             m_epSquare(epSquare),
             m_castlingRights(castlingRights),
             m_rule50Counter(0),
-            m_ply(0)
+            m_ply(0),
+            m_potionZones{},
+            m_potionCooldowns{}
         {
         }
 
@@ -408,6 +419,28 @@ namespace chess
             m_ply = 2 * hm - 1 + (m_sideToMove == Color::Black);
         }
 
+        void setPotionZone(Color c, int potionType,
+                           const std::bitset<static_cast<size_t>(Square::NB)>& zone)
+        {
+            m_potionZones[static_cast<size_t>(c)][potionType] = zone;
+        }
+
+        [[nodiscard]] const std::bitset<static_cast<size_t>(Square::NB)>& potionZone(
+            Color c, int potionType) const
+        {
+            return m_potionZones[static_cast<size_t>(c)][potionType];
+        }
+
+        void setPotionCooldown(Color c, int potionType, std::uint16_t value)
+        {
+            m_potionCooldowns[static_cast<size_t>(c)][potionType] = value;
+        }
+
+        [[nodiscard]] std::uint16_t potionCooldown(Color c, int potionType) const
+        {
+            return m_potionCooldowns[static_cast<size_t>(c)][potionType];
+        }
+
         [[nodiscard]] constexpr Color sideToMove() const
         {
             return m_sideToMove;
@@ -434,6 +467,10 @@ namespace chess
         CastlingRights m_castlingRights;
         std::uint8_t m_rule50Counter;
         std::uint16_t m_ply;
+        std::array<std::array<std::bitset<static_cast<size_t>(Square::NB)>, POTION_TYPE_NB>,
+                   static_cast<size_t>(Color::NB)> m_potionZones;
+        std::array<std::array<std::uint16_t, POTION_TYPE_NB>,
+                   static_cast<size_t>(Color::NB)> m_potionCooldowns;
 
         static_assert(sizeof(Color) + sizeof(Square) + sizeof(CastlingRights) + sizeof(std::uint8_t) == 4);
     };
@@ -459,17 +496,22 @@ namespace bin
 
         using namespace std;
 
+        constexpr int POTION_TYPE_NB = chess::POTION_TYPE_NB;
+        constexpr int POTION_COOLDOWN_BITS = chess::POTION_COOLDOWN_BITS;
+        constexpr int POTION_FREEZE = 0;
+        constexpr int POTION_JUMP = 1;
+
         struct StockfishMove
         {
             [[nodiscard]] chess::Move toMove() const
             {
-                const chess::Square to = static_cast<chess::Square>((m_raw & (0b111111 << 0) >> 0));
-                const chess::Square from = static_cast<chess::Square>((m_raw & (0b111111 << 6)) >> 6);
+                const chess::Square to = static_cast<chess::Square>((m_raw & (0b111111u << 0)) >> 0);
+                const chess::Square from = static_cast<chess::Square>((m_raw & (0b111111u << 6)) >> 6);
 
-                const unsigned promotionIndex = (m_raw & (0b11 << 12)) >> 12;
+                const unsigned promotionIndex = (m_raw & (0b11u << 12)) >> 12;
                 const chess::PieceType promotionType = static_cast<chess::PieceType>(static_cast<int>(chess::PieceType::Knight) + promotionIndex);
 
-                const unsigned moveFlag = (m_raw & (0b11 << 14)) >> 14;
+                const unsigned moveFlag = (m_raw & (0b11u << 14)) >> 14;
                 chess::MoveType type = chess::MoveType::Normal;
                 if (moveFlag == 1) type = chess::MoveType::Promotion;
                 else if (moveFlag == 2) type = chess::MoveType::EnPassant;
@@ -485,9 +527,9 @@ namespace bin
             }
 
         private:
-            std::uint16_t m_raw;
+            std::uint32_t m_raw;
         };
-        static_assert(sizeof(StockfishMove) == sizeof(std::uint16_t));
+        static_assert(sizeof(StockfishMove) == sizeof(std::uint32_t));
 
         struct PackedSfen
         {
@@ -516,12 +558,12 @@ namespace bin
             int8_t game_result;
 
             // When exchanging the file that wrote the teacher aspect with other people
-            //Because this structure size is not fixed, pad it so that it is 40 bytes in any environment.
+            //Because this structure size is not fixed, pad it so that it is DATA_SIZE / 8 + 12 bytes in any environment.
             uint8_t padding;
 
-            // 32 + 2 + 2 + 2 + 1 + 1 = 40bytes
+            // DATA_SIZE / 8 + 4 + 2 + 2 + 1 + 1 (with natural alignment)
         };
-        static_assert(sizeof(PackedSfenValue) == DATA_SIZE / 8 + 8);
+        static_assert(sizeof(PackedSfenValue) == DATA_SIZE / 8 + 12);
         // Class that handles bitstream
 
         // useful when doing aspect encoding
@@ -672,6 +714,41 @@ namespace bin
         };
 
 
+        inline bool on_board(int file, int rank)
+        {
+            return file >= 0 && file < int(chess::File::FILE_NB)
+                   && rank >= 0 && rank < int(chess::Rank::RANK_NB);
+        }
+
+        inline std::bitset<static_cast<size_t>(chess::Square::NB)>
+        potion_zone_from_center(chess::Square center, int potionType)
+        {
+            std::bitset<static_cast<size_t>(chess::Square::NB)> zone;
+            if (center == chess::Square::NB)
+                return zone;
+            if (potionType == POTION_FREEZE)
+            {
+                const int cf = static_cast<int>(chess::file_of(center));
+                const int cr = static_cast<int>(chess::rank_of(center));
+                for (int df = -1; df <= 1; ++df)
+                    for (int dr = -1; dr <= 1; ++dr)
+                    {
+                        const int nf = cf + df;
+                        const int nr = cr + dr;
+                        if (!on_board(nf, nr))
+                            continue;
+                        zone.set(static_cast<size_t>(chess::make_square(
+                            static_cast<chess::File>(nf),
+                            static_cast<chess::Rank>(nr))));
+                    }
+            }
+            else
+            {
+                zone.set(static_cast<size_t>(center));
+            }
+            return zone;
+        }
+
         [[nodiscard]] inline chess::Position pos_from_packed_sfen(const PackedSfen& sfen)
         {
             SfenPacker packer;
@@ -706,9 +783,26 @@ namespace bin
                 }
             }
 
-            for (chess::Color c : { chess::Color::White, chess::Color::Black })
+            for (chess::Color c : { chess::Color::White, chess::Color::Black }) 
                 for (chess::PieceType pt = chess::PieceType::Pawn; pt <= chess::PieceType::MaxPiece; ++pt)
                     pos.setHandCount(make_piece(pt, c), static_cast<int>(stream.read_n_bit(DATA_SIZE > 512 ? 7 : 5)));
+
+            if constexpr (HAS_POTIONS)
+            {
+                for (chess::Color c : { chess::Color::White, chess::Color::Black })
+                    for (int pt = 0; pt < POTION_TYPE_NB; ++pt)
+                    {
+                        const bool has_zone = stream.read_one_bit() != 0;
+                        chess::Square zone_square =
+                            static_cast<chess::Square>(stream.read_n_bit(7));
+                        const std::uint16_t cooldown =
+                            static_cast<std::uint16_t>(stream.read_n_bit(POTION_COOLDOWN_BITS));
+                        if (!has_zone)
+                            zone_square = chess::Square::NB;
+                        pos.setPotionZone(c, pt, potion_zone_from_center(zone_square, pt));
+                        pos.setPotionCooldown(c, pt, cooldown);
+                    }
+            }
 
             // Castling availability.
             chess::CastlingRights cr = chess::CastlingRights::None;

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -218,10 +218,22 @@ struct HalfKAv2 {
     static constexpr int NUM_KSQ = static_cast<int>(Square::KNB);
     static constexpr int NUM_SQ = static_cast<int>(Square::NB);
     static constexpr int NUM_PT = (static_cast<int>(PieceType::MaxPiece) + 1) * 2 - (NUM_KSQ > 1);
-    static constexpr int NUM_PLANES = NUM_SQ * NUM_PT + MAX_HAND_PIECES * (NUM_PT - (NUM_KSQ > 1));
+    static constexpr bool USE_POTIONS = HAS_POTIONS;
+    static constexpr int COLOR_COUNT = static_cast<int>(Color::NB);
+    static constexpr int POTION_ZONE_PLANES = USE_POTIONS ? COLOR_COUNT * POTION_TYPE_NB : 0;
+    static constexpr int POTION_ZONE_FEATURES = POTION_ZONE_PLANES * NUM_SQ;
+    static constexpr int POTION_COOLDOWN_FEATURES =
+        USE_POTIONS ? COLOR_COUNT * POTION_TYPE_NB * POTION_COOLDOWN_BITS : 0;
+    static constexpr int NUM_PLANES_BASE =
+        NUM_SQ * NUM_PT + MAX_HAND_PIECES * (NUM_PT - (NUM_KSQ > 1));
+    static constexpr int POTION_ZONE_OFFSET = NUM_PLANES_BASE;
+    static constexpr int POTION_COOLDOWN_OFFSET = POTION_ZONE_OFFSET + POTION_ZONE_FEATURES;
+    static constexpr int NUM_PLANES =
+        NUM_PLANES_BASE + POTION_ZONE_FEATURES + POTION_COOLDOWN_FEATURES;
     static constexpr int INPUTS = NUM_PLANES * NUM_KSQ;
 
-    static constexpr int MAX_ACTIVE_FEATURES = MAX_PIECES;
+    static constexpr int MAX_ACTIVE_FEATURES =
+        MAX_PIECES + POTION_ZONE_FEATURES + POTION_COOLDOWN_FEATURES;
 
     static int feature_index(Color color, Square ksq, Square sq, Piece p)
     {
@@ -235,6 +247,24 @@ struct HalfKAv2 {
     {
         auto p_idx = static_cast<int>(type_of(p)) * 2 + (color_of(p) != color);
         return handCount + p_idx * MAX_HAND_PIECES + NUM_SQ * NUM_PT + map_king(ksq) * NUM_PLANES;
+    }
+
+    static int potion_zone_feature_index(Color perspective, Square ksq, Color potionColor,
+                                         int potionType, Square sq)
+    {
+        const int potionIndex = potionType + POTION_TYPE_NB * static_cast<int>(potionColor);
+        return static_cast<int>(orient_flip(perspective, sq))
+               + POTION_ZONE_OFFSET + potionIndex * NUM_SQ
+               + map_king(ksq) * NUM_PLANES;
+    }
+
+    static int potion_cooldown_feature_index(Color perspective, Square ksq, Color potionColor,
+                                             int potionType, int bit)
+    {
+        const int potionIndex = potionType + POTION_TYPE_NB * static_cast<int>(potionColor);
+        return bit + POTION_COOLDOWN_OFFSET
+               + potionIndex * POTION_COOLDOWN_BITS
+               + map_king(ksq) * NUM_PLANES;
     }
 
     static std::pair<int, int> fill_features_sparse(const TrainingDataEntry& e, int* features, float* values, Color color)
@@ -262,6 +292,32 @@ struct HalfKAv2 {
                     ++j;
                 }
 
+        if constexpr (USE_POTIONS)
+        {
+            for (Color c : { Color::White, Color::Black })
+                for (int pt = 0; pt < POTION_TYPE_NB; ++pt)
+                {
+                    const auto& zone = pos.potionZone(c, pt);
+                    for (Square sq = Square::MIN; sq <= Square::MAX; ++sq)
+                    {
+                        if (!zone.test(static_cast<size_t>(sq)))
+                            continue;
+                        values[j] = 1.0f;
+                        features[j] = potion_zone_feature_index(color, orient_flip(color, ksq), c, pt, sq);
+                        ++j;
+                    }
+                    std::uint16_t cooldown = pos.potionCooldown(c, pt);
+                    for (int bit = 0; bit < POTION_COOLDOWN_BITS; ++bit)
+                    {
+                        if (!(cooldown & (1u << bit)))
+                            continue;
+                        values[j] = 1.0f;
+                        features[j] = potion_cooldown_feature_index(color, orient_flip(color, ksq), c, pt, bit);
+                        ++j;
+                    }
+                }
+        }
+
         return { j, INPUTS };
     }
 };
@@ -269,10 +325,16 @@ struct HalfKAv2 {
 struct HalfKAv2Factorized {
     // Factorized features
     static constexpr int NUM_PT = (static_cast<int>(PieceType::MaxPiece) + 1) * 2;
-    static constexpr int PIECE_INPUTS = HalfKAv2::NUM_SQ * NUM_PT + MAX_HAND_PIECES * (NUM_PT - 2 * (HalfKAv2::NUM_KSQ > 1));
+    static constexpr int POTION_ZONE_OFFSET =
+        HalfKAv2::NUM_SQ * NUM_PT + MAX_HAND_PIECES * (NUM_PT - 2 * (HalfKAv2::NUM_KSQ > 1));
+    static constexpr int POTION_COOLDOWN_OFFSET =
+        POTION_ZONE_OFFSET + HalfKAv2::POTION_ZONE_FEATURES;
+    static constexpr int PIECE_INPUTS =
+        POTION_COOLDOWN_OFFSET + HalfKAv2::POTION_COOLDOWN_FEATURES;
     static constexpr int INPUTS = HalfKAv2::INPUTS + PIECE_INPUTS;
 
-    static constexpr int MAX_PIECE_FEATURES = MAX_PIECES;
+    static constexpr int MAX_PIECE_FEATURES =
+        MAX_PIECES + HalfKAv2::POTION_ZONE_FEATURES + HalfKAv2::POTION_COOLDOWN_FEATURES;
     static constexpr int MAX_ACTIVE_FEATURES = HalfKAv2::MAX_ACTIVE_FEATURES + MAX_PIECE_FEATURES;
 
     static std::pair<int, int> fill_features_sparse(const TrainingDataEntry& e, int* features, float* values, Color color)
@@ -301,6 +363,38 @@ struct HalfKAv2Factorized {
                     features[j] = offset + i + p_idx * MAX_HAND_PIECES + HalfKAv2::NUM_SQ * NUM_PT;
                     ++j;
                 }
+
+        if constexpr (HalfKAv2::USE_POTIONS)
+        {
+            for (Color c : { Color::White, Color::Black })
+                for (int pt = 0; pt < POTION_TYPE_NB; ++pt)
+                {
+                    const auto& zone = pos.potionZone(c, pt);
+                    for (Square sq = Square::MIN; sq <= Square::MAX; ++sq)
+                    {
+                        if (!zone.test(static_cast<size_t>(sq)))
+                            continue;
+                        values[j] = 1.0f;
+                        const int potionIndex = pt + POTION_TYPE_NB * static_cast<int>(c);
+                        features[j] = offset + POTION_ZONE_OFFSET
+                                      + potionIndex * HalfKAv2::NUM_SQ
+                                      + static_cast<int>(orient_flip(color, sq));
+                        ++j;
+                    }
+                    std::uint16_t cooldown = pos.potionCooldown(c, pt);
+                    for (int bit = 0; bit < POTION_COOLDOWN_BITS; ++bit)
+                    {
+                        if (!(cooldown & (1u << bit)))
+                            continue;
+                        values[j] = 1.0f;
+                        const int potionIndex = pt + POTION_TYPE_NB * static_cast<int>(c);
+                        features[j] = offset + POTION_COOLDOWN_OFFSET
+                                      + potionIndex * POTION_COOLDOWN_BITS
+                                      + bit;
+                        ++j;
+                    }
+                }
+        }
 
         return { j, INPUTS };
     }

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -252,7 +252,8 @@ struct HalfKAv2 {
     static int potion_zone_feature_index(Color perspective, Square ksq, Color potionColor,
                                          int potionType, Square sq)
     {
-        const int potionIndex = potionType + POTION_TYPE_NB * static_cast<int>(potionColor);
+        const int relativeColor = static_cast<int>(potionColor != perspective);
+        const int potionIndex = potionType + POTION_TYPE_NB * relativeColor;
         return static_cast<int>(orient_flip(perspective, sq))
                + POTION_ZONE_OFFSET + potionIndex * NUM_SQ
                + map_king(ksq) * NUM_PLANES;
@@ -261,7 +262,8 @@ struct HalfKAv2 {
     static int potion_cooldown_feature_index(Color perspective, Square ksq, Color potionColor,
                                              int potionType, int bit)
     {
-        const int potionIndex = potionType + POTION_TYPE_NB * static_cast<int>(potionColor);
+        const int relativeColor = static_cast<int>(potionColor != perspective);
+        const int potionIndex = potionType + POTION_TYPE_NB * relativeColor;
         return bit + POTION_COOLDOWN_OFFSET
                + potionIndex * POTION_COOLDOWN_BITS
                + map_king(ksq) * NUM_PLANES;
@@ -375,7 +377,7 @@ struct HalfKAv2Factorized {
                         if (!zone.test(static_cast<size_t>(sq)))
                             continue;
                         values[j] = 1.0f;
-                        const int potionIndex = pt + POTION_TYPE_NB * static_cast<int>(c);
+                        const int potionIndex = pt + POTION_TYPE_NB * static_cast<int>(c != color);
                         features[j] = offset + POTION_ZONE_OFFSET
                                       + potionIndex * HalfKAv2::NUM_SQ
                                       + static_cast<int>(orient_flip(color, sq));
@@ -387,7 +389,7 @@ struct HalfKAv2Factorized {
                         if (!(cooldown & (1u << bit)))
                             continue;
                         values[j] = 1.0f;
-                        const int potionIndex = pt + POTION_TYPE_NB * static_cast<int>(c);
+                        const int potionIndex = pt + POTION_TYPE_NB * static_cast<int>(c != color);
                         features[j] = offset + POTION_COOLDOWN_OFFSET
                                       + potionIndex * POTION_COOLDOWN_BITS
                                       + bit;

--- a/variant.h
+++ b/variant.h
@@ -1,7 +1,8 @@
 #define FILES 8
 #define RANKS 8
-#define PIECE_TYPES 6
-#define PIECE_COUNT 32
-#define POCKETS false
+#define PIECE_TYPES 8
+#define PIECE_COUNT 46
+#define POCKETS true
 #define KING_SQUARES FILES * RANKS
 #define DATA_SIZE 512
+#define HAS_POTIONS 1

--- a/variant.py
+++ b/variant.py
@@ -2,10 +2,12 @@ RANKS = 8
 FILES = 8
 SQUARES = RANKS * FILES
 KING_SQUARES = RANKS * FILES
-PIECE_TYPES = 6
+PIECE_TYPES = 8  # P N B R Q F J K (spell-chess)
 PIECES = 2 * PIECE_TYPES
-USE_POCKETS = False
+USE_POCKETS = True  # spells in hand ride the pockets
 POCKETS = 2 * FILES if USE_POCKETS else 0
+
+HAS_POTIONS = True  # spell-chess zone/cooldown feature planes
 
 PIECE_VALUES = {
     1 : 126,
@@ -13,4 +15,6 @@ PIECE_VALUES = {
     3 : 825,
     4 : 1276,
     5 : 2538,
+    6 : 0,     # F (spell, never on the board)
+    7 : 0,     # J (spell, never on the board)
 }


### PR DESCRIPTION
  - Decode potion zone + cooldown bits into Position when HAS_POTIONS is true.
  - Add potion planes and cooldown bits to HalfKAv2 feature extraction (including factorized features).
  - Use legacy hash for non‑potion variants and new hash 0x7c2d4f9e for potions.