### PR TITLE
H7.1: expose the Legacy Atomic schema handshake

### DIFF
--- a/docs/legacy-atomic-v1.md
+++ b/docs/legacy-atomic-v1.md
@@ -44,7 +44,7 @@ The native library exports the read-only C ABI
 fresh dictionary:
 
 ```json
-{"schema_sha256":"758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78","formats":{"legacy-atomic-v1":{"read":true,"write":false,"record_size":72}}}
+{"schema_sha256":"acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1","formats":{"legacy-atomic-v1":{"read":true,"write":false,"record_size":72}}}
 ```
 
 This is a capability handshake, not format negotiation. The loader only reads

--- a/docs/legacy-atomic-v1.md
+++ b/docs/legacy-atomic-v1.md
@@ -38,6 +38,21 @@ SHA-256:
 9749b7673746e51177327081b8982a7962e4f7fbeb80561f69dd16c953970b91
 ```
 
+The native library exports the read-only C ABI
+`get_atomic_training_data_schema_json()`. Python callers use
+`nnue_dataset.atomic_training_data_schema()` to receive the same metadata as a
+fresh dictionary:
+
+```json
+{"schema_sha256":"758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78","formats":{"legacy-atomic-v1":{"read":true,"write":false,"record_size":72}}}
+```
+
+This is a capability handshake, not format negotiation. The loader only reads
+headerless Legacy Atomic V1 `.bin` records, does not write datasets, and does
+not probe or fall back to the future `atomic-bin-v2` format. The C function
+returns a NUL-terminated pointer to immutable static storage that remains valid
+for the process lifetime; callers must neither modify nor free it.
+
 The seed is applied before model construction and is forwarded to the native
 stream. Input reads receive monotonically increasing sequence numbers while
 feature extraction may run concurrently, so yielded batch order is identical

--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -1,5 +1,6 @@
 import numpy as np
 import ctypes
+import json
 import torch
 import os
 import sys
@@ -75,6 +76,35 @@ SparseBatchPtr = ctypes.POINTER(SparseBatch)
 
 INT32_MAX = 2**31 - 1
 UINT64_MAX = 2**64 - 1
+
+
+def _bind_atomic_training_data_schema(library):
+    try:
+        function = library.get_atomic_training_data_schema_json
+    except AttributeError as error:
+        raise RuntimeError(
+            'Training data loader does not expose the Atomic schema handshake; rebuild the native library'
+        ) from error
+    function.restype = ctypes.c_char_p
+    function.argtypes = []
+    return function
+
+
+get_atomic_training_data_schema_json = _bind_atomic_training_data_schema(dll)
+
+
+def atomic_training_data_schema():
+    """Return the native loader's read-only Atomic dataset capabilities."""
+    payload = get_atomic_training_data_schema_json()
+    if payload is None:
+        raise RuntimeError('Native data loader returned no Atomic training-data schema')
+    try:
+        document = json.loads(payload.decode('utf-8'))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RuntimeError('Native data loader returned invalid Atomic training-data schema JSON') from error
+    if not isinstance(document, dict):
+        raise RuntimeError('Native Atomic training-data schema must be a JSON object')
+    return document
 
 
 def _bounded_integer(name, value, minimum, maximum):

--- a/tests/native_loader_tests.cpp
+++ b/tests/native_loader_tests.cpp
@@ -244,7 +244,7 @@ static void test_atomic_training_data_schema_handshake()
     const char* schema_json = get_atomic_training_data_schema_json();
     assert(schema_json != nullptr);
     assert(std::string(schema_json) ==
-        "{\"schema_sha256\":\"758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78\","
+        "{\"schema_sha256\":\"acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1\","
         "\"formats\":{\"legacy-atomic-v1\":{\"read\":true,\"write\":false,"
         "\"record_size\":72}}}");
 }

--- a/tests/native_loader_tests.cpp
+++ b/tests/native_loader_tests.cpp
@@ -239,6 +239,16 @@ static void test_c_api_validation()
     assert(fetch_next_sparse_batch(nullptr) == nullptr);
 }
 
+static void test_atomic_training_data_schema_handshake()
+{
+    const char* schema_json = get_atomic_training_data_schema_json();
+    assert(schema_json != nullptr);
+    assert(std::string(schema_json) ==
+        "{\"schema_sha256\":\"758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78\","
+        "\"formats\":{\"legacy-atomic-v1\":{\"read\":true,\"write\":false,"
+        "\"record_size\":72}}}");
+}
+
 static void test_corrupt_full_size_records_fail_closed()
 {
     const auto valid = valid_legacy_record();
@@ -306,6 +316,7 @@ int main()
     test_smart_filter();
     test_seeded_random_skipping();
     test_c_api_validation();
+    test_atomic_training_data_schema_handshake();
     test_corrupt_full_size_records_fail_closed();
     return 0;
 }

--- a/tests/test_native_loader_integration.py
+++ b/tests/test_native_loader_integration.py
@@ -7,6 +7,47 @@ import torch
 import nnue_dataset
 
 
+def test_atomic_training_data_schema_handshake():
+    expected = {
+        'schema_sha256': '758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78',
+        'formats': {
+            'legacy-atomic-v1': {
+                'read': True,
+                'write': False,
+                'record_size': 72,
+            },
+        },
+    }
+    first = nnue_dataset.atomic_training_data_schema()
+    second = nnue_dataset.atomic_training_data_schema()
+
+    assert first == expected
+    assert second == expected
+    assert first is not second
+    assert first['formats'] is not second['formats']
+
+
+@pytest.mark.parametrize(
+    ('payload', 'message'),
+    [
+        (None, 'returned no'),
+        (b'\xff', 'invalid'),
+        (b'not-json', 'invalid'),
+        (b'[]', 'must be a JSON object'),
+    ],
+)
+def test_atomic_training_data_schema_rejects_invalid_native_payloads(monkeypatch, payload, message):
+    monkeypatch.setattr(nnue_dataset, 'get_atomic_training_data_schema_json', lambda: payload)
+
+    with pytest.raises(RuntimeError, match=message):
+        nnue_dataset.atomic_training_data_schema()
+
+
+def test_atomic_training_data_schema_requires_native_symbol():
+    with pytest.raises(RuntimeError, match='rebuild the native library'):
+        nnue_dataset._bind_atomic_training_data_schema(object())
+
+
 def batch_digest(batch):
     digest = hashlib.sha256()
     for tensor in batch:

--- a/tests/test_native_loader_integration.py
+++ b/tests/test_native_loader_integration.py
@@ -9,7 +9,7 @@ import nnue_dataset
 
 def test_atomic_training_data_schema_handshake():
     expected = {
-        'schema_sha256': '758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78',
+        'schema_sha256': 'acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1',
         'formats': {
             'legacy-atomic-v1': {
                 'read': True,

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -38,6 +38,20 @@ using namespace chess;
 static constexpr int MAX_PIECES = PIECE_COUNT;
 static constexpr int MAX_HAND_PIECES = POCKETS ? 2 * static_cast<int>(File::FILE_NB) : 0;
 
+namespace {
+
+constexpr char ATOMIC_TRAINING_DATA_SCHEMA_JSON[] =
+    "{\"schema_sha256\":\"758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78\","
+    "\"formats\":{\"legacy-atomic-v1\":{\"read\":true,\"write\":false,"
+    "\"record_size\":72}}}";
+
+static_assert(
+    sizeof(bin::nodchip::PackedSfenValue) == 72,
+    "legacy-atomic-v1 schema metadata requires 72-byte records"
+);
+
+}
+
 static Square orient(Color color, Square sq)
 {
     if (color == Color::White)
@@ -813,6 +827,11 @@ std::function<bool(const TrainingDataEntry&)> make_skip_predicate(bool filtered,
 }
 
 extern "C" {
+
+    EXPORT const char* CDECL get_atomic_training_data_schema_json()
+    {
+        return ATOMIC_TRAINING_DATA_SCHEMA_JSON;
+    }
 
     EXPORT Stream<SparseBatch>* CDECL create_sparse_batch_stream_with_seed(const char* feature_set_c, int concurrency, const char* filename, int batch_size, bool cyclic, bool filtered, int random_fen_skipping, std::uint64_t seed)
     {

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -38,10 +38,15 @@ using namespace chess;
 static constexpr int MAX_PIECES = PIECE_COUNT;
 static constexpr int MAX_HAND_PIECES = POCKETS ? 2 * static_cast<int>(File::FILE_NB) : 0;
 
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) \
+  && __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#  error "legacy-atomic-v1 requires a little-endian host"
+#endif
+
 namespace {
 
 constexpr char ATOMIC_TRAINING_DATA_SCHEMA_JSON[] =
-    "{\"schema_sha256\":\"758ac9239c2b1cff34cd10e185d9ee1bc7a400e2758bb1ce71171e1a1fa50a78\","
+    "{\"schema_sha256\":\"acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1\","
     "\"formats\":{\"legacy-atomic-v1\":{\"read\":true,\"write\":false,"
     "\"record_size\":72}}}";
 


### PR DESCRIPTION
## Summary

- export `get_atomic_training_data_schema_json()` from the native loader
- expose a fresh-dictionary Python wrapper, `atomic_training_data_schema()`
- advertise exact Legacy Atomic V1 schema/read-only capabilities and fail clearly on an old DLL
- reject unsupported host byte order at compile time
- document C ABI pointer ownership and lifetime

This is the trainer side of the Atomic-Stockfish H7.1 tri-repository compatibility boundary. The normative schema SHA-256 is `acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1`.

## Validation

- MSVC x64 Release build/install: PASS
- native CTest: 1/1
- full Python CPU suite: 58/58
- required CUDA/CuPy suite on RTX 3080: 58/58
- clean build manifest recorded at commit `350a28f2cee225c546333aded75b9db64caa526d`
- full generator → trainer → serialized NNUE → Atomic-Stockfish E2E: PASS