### PR TITLE
Hito 7: read authenticated Atomic BIN V2 datasets

### DIFF
--- a/.github/workflows/trainer-tests.yml
+++ b/.github/workflows/trainer-tests.yml
@@ -25,6 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Fetch audited Atomic-Stockfish main ref
+        run: git -C external/Atomic-Stockfish fetch --no-tags origin main:refs/remotes/origin/main
 
       - uses: actions/setup-python@v5
         with:
@@ -56,6 +61,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Fetch audited Atomic-Stockfish main ref
+        run: git -C external/Atomic-Stockfish fetch --no-tags origin main:refs/remotes/origin/main
 
       - uses: actions/setup-python@v5
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/Atomic-Stockfish"]
+	path = external/Atomic-Stockfish
+	url = https://github.com/Belzedar94/Atomic-Stockfish.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,112 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(ATOMIC_STOCKFISH_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/external/Atomic-Stockfish")
+set(ATOMIC_STOCKFISH_PIN "1e64c6f16e8c327be6ee5e3de57ed54d1079f060")
+set(ATOMIC_BIN_V2_DATA_SCHEMA_SHA256
+  "0352b036f2a140c609e3eb9c9d635dc553e8d77253d8faa92437390f5cf93cb6")
+set(ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256
+  "83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42")
+if(NOT EXISTS "${ATOMIC_STOCKFISH_ROOT}/src/data/atomic_bin_v2_reader.cpp")
+  message(FATAL_ERROR
+    "Atomic-Stockfish submodule is missing; run git submodule update --init --recursive")
+endif()
+
+find_package(Git REQUIRED)
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} config --file ${CMAKE_CURRENT_SOURCE_DIR}/.gitmodules
+    --get submodule.external/Atomic-Stockfish.url
+  OUTPUT_VARIABLE ATOMIC_STOCKFISH_URL
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE ATOMIC_STOCKFISH_URL_RESULT)
+if(NOT ATOMIC_STOCKFISH_URL_RESULT EQUAL 0
+   OR NOT ATOMIC_STOCKFISH_URL STREQUAL "https://github.com/Belzedar94/Atomic-Stockfish.git")
+  message(FATAL_ERROR "Atomic-Stockfish submodule URL differs from the audited upstream")
+endif()
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} -C ${ATOMIC_STOCKFISH_ROOT} remote get-url origin
+  OUTPUT_VARIABLE ATOMIC_STOCKFISH_ORIGIN_URL
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE ATOMIC_STOCKFISH_ORIGIN_URL_RESULT)
+if(NOT ATOMIC_STOCKFISH_ORIGIN_URL_RESULT EQUAL 0
+   OR NOT ATOMIC_STOCKFISH_ORIGIN_URL STREQUAL "https://github.com/Belzedar94/Atomic-Stockfish.git")
+  message(FATAL_ERROR "Atomic-Stockfish submodule origin URL differs from the audited upstream")
+endif()
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR}
+    rev-parse :external/Atomic-Stockfish
+  OUTPUT_VARIABLE ATOMIC_STOCKFISH_GITLINK
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE ATOMIC_STOCKFISH_GITLINK_RESULT)
+if(NOT ATOMIC_STOCKFISH_GITLINK_RESULT EQUAL 0
+   OR NOT ATOMIC_STOCKFISH_GITLINK STREQUAL ATOMIC_STOCKFISH_PIN)
+  message(FATAL_ERROR "Atomic-Stockfish gitlink differs from the audited pin")
+endif()
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} -C ${ATOMIC_STOCKFISH_ROOT} rev-parse HEAD
+  OUTPUT_VARIABLE ATOMIC_STOCKFISH_HEAD
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE ATOMIC_STOCKFISH_HEAD_RESULT)
+if(NOT ATOMIC_STOCKFISH_HEAD_RESULT EQUAL 0
+   OR NOT ATOMIC_STOCKFISH_HEAD STREQUAL ATOMIC_STOCKFISH_PIN)
+  message(FATAL_ERROR
+    "Atomic-Stockfish must be pinned exactly to ${ATOMIC_STOCKFISH_PIN}; "
+    "run git submodule update --init --recursive")
+endif()
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} -C ${ATOMIC_STOCKFISH_ROOT} status --porcelain
+  OUTPUT_VARIABLE ATOMIC_STOCKFISH_STATUS
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE ATOMIC_STOCKFISH_STATUS_RESULT)
+if(NOT ATOMIC_STOCKFISH_STATUS_RESULT EQUAL 0 OR NOT ATOMIC_STOCKFISH_STATUS STREQUAL "")
+  message(FATAL_ERROR "Atomic-Stockfish submodule must be clean")
+endif()
+execute_process(
+  COMMAND ${GIT_EXECUTABLE} -C ${ATOMIC_STOCKFISH_ROOT}
+    merge-base --is-ancestor ${ATOMIC_STOCKFISH_PIN} origin/main
+  RESULT_VARIABLE ATOMIC_STOCKFISH_MAIN_RESULT)
+if(NOT ATOMIC_STOCKFISH_MAIN_RESULT EQUAL 0)
+  message(FATAL_ERROR
+    "Pinned Atomic-Stockfish commit must be an ancestor of origin/main; fetch the submodule remote")
+endif()
+
+file(SHA256
+  "${ATOMIC_STOCKFISH_ROOT}/schemas/atomic-bin-v2.json"
+  ATOMIC_BIN_V2_DATA_SCHEMA_ACTUAL)
+file(SHA256
+  "${ATOMIC_STOCKFISH_ROOT}/schemas/atomic-bin-v2-manifest.json"
+  ATOMIC_BIN_V2_MANIFEST_SCHEMA_ACTUAL)
+if(NOT ATOMIC_BIN_V2_DATA_SCHEMA_ACTUAL STREQUAL ATOMIC_BIN_V2_DATA_SCHEMA_SHA256)
+  message(FATAL_ERROR "Pinned Atomic BIN V2 data schema hash differs")
+endif()
+if(NOT ATOMIC_BIN_V2_MANIFEST_SCHEMA_ACTUAL STREQUAL ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256)
+  message(FATAL_ERROR "Pinned Atomic BIN V2 manifest schema hash differs")
+endif()
+
+add_library(atomic_bin_v2_reader_core STATIC
+  ${ATOMIC_STOCKFISH_ROOT}/src/atomic_init.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/attacks.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/bitboard.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/misc.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/movegen.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/position.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/syzygy/tbprobe.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/uci_move.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/ucioption.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/data/atomic_bin_v2_wire.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/data/atomic_bin_v2.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/data/sha256.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/data/atomic_bin_v2_manifest.cpp
+  ${ATOMIC_STOCKFISH_ROOT}/src/data/atomic_bin_v2_reader.cpp
+  lib/atomic_stockfish_tt_stub.cpp)
+set_target_properties(atomic_bin_v2_reader_core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(atomic_bin_v2_reader_core PUBLIC
+  ${ATOMIC_STOCKFISH_ROOT}/src)
+target_compile_definitions(atomic_bin_v2_reader_core PRIVATE NNUE_EMBEDDING_OFF)
+
+add_library(dataset_file_identity STATIC lib/dataset_file_identity.cpp)
+set_target_properties(dataset_file_identity PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 add_library(training_data_loader SHARED training_data_loader.cpp)
 
 if(MSVC)
@@ -26,12 +132,24 @@ endif()
 
 find_package(Threads REQUIRED)
 
-target_link_libraries(training_data_loader Threads::Threads)
+target_link_libraries(training_data_loader PRIVATE
+  atomic_bin_v2_reader_core
+  dataset_file_identity
+  Threads::Threads)
+if(WIN32)
+  target_link_libraries(training_data_loader PRIVATE shell32)
+endif()
 
 include(CTest)
 if(BUILD_TESTING)
   add_executable(training_data_loader_tests tests/native_loader_tests.cpp)
-  target_link_libraries(training_data_loader_tests Threads::Threads)
+  target_link_libraries(training_data_loader_tests PRIVATE
+    atomic_bin_v2_reader_core
+    dataset_file_identity
+    Threads::Threads)
+  if(WIN32)
+    target_link_libraries(training_data_loader_tests PRIVATE shell32)
+  endif()
   if(MSVC)
     target_compile_options(training_data_loader_tests PRIVATE $<$<CONFIG:Release>:/O2>)
   else()
@@ -44,3 +162,4 @@ install(
   TARGETS training_data_loader
   RUNTIME DESTINATION .
   LIBRARY DESTINATION .)
+install(FILES Copying.txt DESTINATION .)

--- a/Copying.txt
+++ b/Copying.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ compile_data_loader.bat
 
 Linux/Mac:
 ```
-sh compile_data_loader.bat
+sh compile_data_loader.sh
 ```
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -66,6 +66,32 @@ source env/bin/activate
 python train.py train_data.bin val_data.bin
 ```
 
+Atomic BIN V2 datasets use their authenticated manifests instead of raw
+shards:
+
+```bash
+python train.py train.atbin.manifest.json val.atbin.manifest.json
+```
+
+See [docs/atomic-bin-v2.md](docs/atomic-bin-v2.md) for the pinned reader,
+schema and generator-policy contract.
+
+## License of the native loader
+
+`training_data_loader` statically links selected source files from
+[Atomic-Stockfish](https://github.com/Belzedar94/Atomic-Stockfish), which is
+derived from Stockfish. The linked native component is distributed under the
+GNU General Public License version 3 or any later version
+(`GPL-3.0-or-later`). See [Copying.txt](Copying.txt) for the complete license
+and [`external/Atomic-Stockfish/AUTHORS`](external/Atomic-Stockfish/AUTHORS)
+for the upstream authors. Copyright 2004-2026 The Stockfish developers and
+other contributors.
+
+The corresponding source for a built loader is this repository at the exact
+trainer commit together with its recursively checked-out Atomic-Stockfish
+submodule. The authenticated engine pin is documented in
+[docs/atomic-bin-v2.md](docs/atomic-bin-v2.md).
+
 Training and validation inputs must be different files. The escape hatch
 `--allow-train-as-validation` exists only for explicit smoke/debug runs and
 must not be used for real training or model comparison.
@@ -75,9 +101,11 @@ batch order is stable across worker counts; validation never applies random
 skipping, even when training does, and restarts from the beginning of its
 dedicated file for every validation pass.
 
-Smart FEN skipping retains the trainer's historical heuristic: positions with
-a teacher capture (including en passant) or a geometric orthodox check are
-skipped. It is a target-quality filter, not an Atomic legal-position oracle.
+For Legacy `.bin` input, smart FEN skipping retains the trainer's historical
+heuristic: positions with a teacher capture (including en passant) or a
+geometric orthodox check are skipped. It is not an Atomic legal-position
+oracle and is therefore bypassed for V2; V2 reports and trusts the authenticated
+generator policy in its manifest.
 
 ## Resuming training
 

--- a/compile_data_loader.bat
+++ b/compile_data_loader.bat
@@ -1,2 +1,7 @@
+git submodule update --init --recursive
+if errorlevel 1 exit /b %errorlevel%
+git -C external/Atomic-Stockfish fetch --no-tags origin main:refs/remotes/origin/main
+if errorlevel 1 exit /b %errorlevel%
 cmake . -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="./"
+if errorlevel 1 exit /b %errorlevel%
 cmake --build ./build --config RelWithDebInfo --target install

--- a/compile_data_loader.bat
+++ b/compile_data_loader.bat
@@ -2,6 +2,7 @@ git submodule update --init --recursive
 if errorlevel 1 exit /b %errorlevel%
 git -C external/Atomic-Stockfish fetch --no-tags origin main:refs/remotes/origin/main
 if errorlevel 1 exit /b %errorlevel%
-cmake . -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="./"
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo "-DCMAKE_INSTALL_PREFIX=%CD%"
 if errorlevel 1 exit /b %errorlevel%
-cmake --build ./build --config RelWithDebInfo --target install
+cmake --build build --config RelWithDebInfo --target install
+if errorlevel 1 exit /b %errorlevel%

--- a/compile_data_loader.sh
+++ b/compile_data_loader.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+git submodule update --init --recursive
+git -C external/Atomic-Stockfish fetch --no-tags origin main:refs/remotes/origin/main
+cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo "-DCMAKE_INSTALL_PREFIX=$(pwd)"
+cmake --build build --config RelWithDebInfo --target install

--- a/docs/atomic-bin-v2.md
+++ b/docs/atomic-bin-v2.md
@@ -1,0 +1,45 @@
+# Atomic BIN V2 trainer input
+
+The trainer accepts Atomic BIN V2 only through its canonical
+`*.atbin.manifest.json` sidecar. Raw `*.atbin` shards are deliberately rejected.
+The native loader delegates manifest parsing, shard snapshots, SHA-256 checks,
+record decoding, Atomic legality and byte-exact canonical validation to the
+pinned Atomic-Stockfish reader.
+
+The engine submodule is fixed to
+`1e64c6f16e8c327be6ee5e3de57ed54d1079f060`. Configuration fails if the
+gitlink, checkout, origin URL, schema hashes or `origin/main` ancestry differ,
+or if the submodule is dirty.
+
+Because the native loader statically links this pinned Atomic-Stockfish code,
+the resulting component is distributed under `GPL-3.0-or-later`. The complete
+license is installed alongside the loader from the repository's
+`Copying.txt`; the recursively checked-out trainer and engine commits are its
+corresponding source.
+
+Legacy Atomic V1 remains available as a headerless 72-byte `.bin` stream. The
+singular schema handshake is byte-for-byte unchanged; the plural handshake
+advertises both formats.
+
+V2 preserves signed 32-bit scores, unsigned 32-bit sample plies, unsigned
+16-bit rule-50 counters, unsigned 32-bit fullmove numbers, Atomic960 castling
+origins and score/result semantics relative to the side to move. Scores are
+converted explicitly to the trainer's float tensor only when a batch is built.
+
+Trainer-side smart filtering is never applied to V2. Its orthodox geometric
+check approximation is retained only for historical Legacy datasets. V2 uses
+and reports the authenticated generator policy in the manifest. The recommended
+Atomic generation profile is:
+
+```text
+Use NNUE=pure
+eval_limit=32000
+filter_captures=true
+filter_promotions=true
+filter_checks=false
+```
+
+Other manifest policies remain valid for controlled experiments. Training and
+validation manifests are rejected when any shards share a SHA-256 digest,
+normalized path or filesystem identity, unless the explicit smoke/debug escape
+hatch is used.

--- a/lib/atomic_bin_v2_training_data.h
+++ b/lib/atomic_bin_v2_training_data.h
@@ -1,0 +1,146 @@
+#ifndef ATOMIC_BIN_V2_TRAINING_DATA_H_
+#define ATOMIC_BIN_V2_TRAINING_DATA_H_
+
+#include "nnue_training_data_formats.h"
+
+#include "../external/Atomic-Stockfish/src/data/atomic_bin_v2_reader.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace training_data
+{
+    namespace atomic_bin_v2
+    {
+        inline chess::Piece piece_from_wire(Stockfish::u8 value)
+        {
+            using namespace Stockfish::Data;
+            switch (value)
+            {
+            case ATOMIC_BIN_V2_EMPTY:
+                return chess::Piece::None;
+            case ATOMIC_BIN_V2_WHITE_PAWN:
+                return chess::make_piece(chess::PieceType::Pawn, chess::Color::White);
+            case ATOMIC_BIN_V2_WHITE_KNIGHT:
+                return chess::make_piece(chess::PieceType::Knight, chess::Color::White);
+            case ATOMIC_BIN_V2_WHITE_BISHOP:
+                return chess::make_piece(chess::PieceType::Bishop, chess::Color::White);
+            case ATOMIC_BIN_V2_WHITE_ROOK:
+                return chess::make_piece(chess::PieceType::Rook, chess::Color::White);
+            case ATOMIC_BIN_V2_WHITE_QUEEN:
+                return chess::make_piece(chess::PieceType::Queen, chess::Color::White);
+            case ATOMIC_BIN_V2_WHITE_KING:
+                return chess::make_piece(chess::PieceType::King, chess::Color::White);
+            case ATOMIC_BIN_V2_BLACK_PAWN:
+                return chess::make_piece(chess::PieceType::Pawn, chess::Color::Black);
+            case ATOMIC_BIN_V2_BLACK_KNIGHT:
+                return chess::make_piece(chess::PieceType::Knight, chess::Color::Black);
+            case ATOMIC_BIN_V2_BLACK_BISHOP:
+                return chess::make_piece(chess::PieceType::Bishop, chess::Color::Black);
+            case ATOMIC_BIN_V2_BLACK_ROOK:
+                return chess::make_piece(chess::PieceType::Rook, chess::Color::Black);
+            case ATOMIC_BIN_V2_BLACK_QUEEN:
+                return chess::make_piece(chess::PieceType::Queen, chess::Color::Black);
+            case ATOMIC_BIN_V2_BLACK_KING:
+                return chess::make_piece(chess::PieceType::King, chess::Color::Black);
+            default:
+                throw std::invalid_argument("Atomic BIN V2 reader returned an unknown piece code");
+            }
+        }
+
+        inline chess::PieceType promotion_from_wire(Stockfish::u8 value)
+        {
+            using namespace Stockfish::Data;
+            switch (value)
+            {
+            case ATOMIC_BIN_V2_PROMOTE_KNIGHT:
+                return chess::PieceType::Knight;
+            case ATOMIC_BIN_V2_PROMOTE_BISHOP:
+                return chess::PieceType::Bishop;
+            case ATOMIC_BIN_V2_PROMOTE_ROOK:
+                return chess::PieceType::Rook;
+            case ATOMIC_BIN_V2_PROMOTE_QUEEN:
+                return chess::PieceType::Queen;
+            default:
+                throw std::invalid_argument("Atomic BIN V2 reader returned an invalid promotion code");
+            }
+        }
+
+        inline chess::Move move_from_fields(
+            const Stockfish::Data::AtomicBinV2MoveFields& fields,
+            chess::Color side_to_move)
+        {
+            using namespace Stockfish::Data;
+            const auto from = static_cast<chess::Square>(fields.from);
+            const auto to = static_cast<chess::Square>(fields.to);
+            switch (fields.type)
+            {
+            case ATOMIC_BIN_V2_NORMAL:
+                return {from, to, chess::MoveType::Normal};
+            case ATOMIC_BIN_V2_EN_PASSANT:
+                return {from, to, chess::MoveType::EnPassant};
+            case ATOMIC_BIN_V2_CASTLING:
+                return {from, to, chess::MoveType::Castle};
+            case ATOMIC_BIN_V2_PROMOTION:
+                return {
+                    from,
+                    to,
+                    chess::MoveType::Promotion,
+                    chess::make_piece(promotion_from_wire(fields.promotion), side_to_move)};
+            default:
+                throw std::invalid_argument("Atomic BIN V2 reader returned an unknown move type");
+            }
+        }
+
+        inline bin::TrainingDataEntry to_training_data_entry(
+            const Stockfish::Data::AtomicBinV2DecodedRecord& decoded)
+        {
+            using namespace Stockfish::Data;
+            const auto& fields = decoded.fields;
+
+            bin::TrainingDataEntry entry{};
+            entry.pos.setCastlingRights(
+                static_cast<chess::CastlingRights>(fields.position.castlingRights));
+            entry.pos.setSideToMove(
+                fields.position.sideToMove == ATOMIC_BIN_V2_WHITE_TO_MOVE
+                    ? chess::Color::White
+                    : chess::Color::Black);
+            entry.pos.setEpSquare(
+                fields.position.enPassantSquare == AtomicBinV2NoSquare
+                    ? chess::Square::NB
+                    : static_cast<chess::Square>(fields.position.enPassantSquare));
+            entry.pos.setRule50Counter(fields.position.rule50);
+            entry.pos.setFullMove(fields.position.fullmove);
+
+            for (std::size_t index = 0; index < fields.position.castlingRookOrigins.size(); ++index)
+            {
+                const auto origin = fields.position.castlingRookOrigins[index];
+                entry.pos.setCastlingRookOrigin(
+                    index,
+                    origin == AtomicBinV2NoSquare
+                        ? chess::Square::NB
+                        : static_cast<chess::Square>(origin));
+            }
+
+            for (std::size_t square = 0; square < fields.position.board.size(); ++square)
+            {
+                const chess::Piece piece = piece_from_wire(fields.position.board[square]);
+                if (piece != chess::Piece::None)
+                    entry.pos.place(piece, static_cast<chess::Square>(square));
+            }
+
+            entry.move = move_from_fields(fields.move, entry.pos.sideToMove());
+            entry.score = fields.score;
+            entry.ply = fields.ply;
+            entry.result = fields.result;
+            entry.flags = (fields.flags & ATOMIC_BIN_V2_ATOMIC960)
+                ? bin::TrainingDataAtomic960
+                : bin::NoTrainingDataFlags;
+            return entry;
+        }
+    }
+}
+
+#endif

--- a/lib/atomic_stockfish_tt_stub.cpp
+++ b/lib/atomic_stockfish_tt_stub.cpp
@@ -1,0 +1,12 @@
+#include "../external/Atomic-Stockfish/src/tt.h"
+
+namespace Stockfish
+{
+    // The authenticated dataset reader never supplies a transposition table
+    // to Position::do_move(). Keep the loader isolated from the engine's
+    // threaded TT subsystem, matching Atomic-Stockfish's standalone reader.
+    TTEntry* TranspositionTable::first_entry(Key) const
+    {
+        return nullptr;
+    }
+}

--- a/lib/dataset_file_identity.cpp
+++ b/lib/dataset_file_identity.cpp
@@ -1,0 +1,48 @@
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#endif
+
+#include "dataset_file_identity.h"
+
+namespace training_data::platform
+{
+    std::optional<DatasetFileIdentity> dataset_file_identity(
+        const std::filesystem::path& path) noexcept
+    {
+#if defined(_WIN32)
+        const HANDLE handle = CreateFileW(
+            path.c_str(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            nullptr);
+        if (handle == INVALID_HANDLE_VALUE)
+            return std::nullopt;
+        BY_HANDLE_FILE_INFORMATION information{};
+        const bool inspected = bool(GetFileInformationByHandle(handle, &information));
+        CloseHandle(handle);
+        if (!inspected)
+            return std::nullopt;
+        return DatasetFileIdentity{
+            information.dwVolumeSerialNumber,
+            (std::uint64_t(information.nFileIndexHigh) << 32) | information.nFileIndexLow};
+#else
+        struct stat information{};
+        if (::stat(path.c_str(), &information) != 0)
+            return std::nullopt;
+        return DatasetFileIdentity{
+            static_cast<std::uint64_t>(information.st_dev),
+            static_cast<std::uint64_t>(information.st_ino)};
+#endif
+    }
+}

--- a/lib/dataset_file_identity.h
+++ b/lib/dataset_file_identity.h
@@ -1,0 +1,28 @@
+#ifndef DATASET_FILE_IDENTITY_H_
+#define DATASET_FILE_IDENTITY_H_
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+
+namespace training_data::platform
+{
+    struct DatasetFileIdentity
+    {
+        std::uint64_t first{};
+        std::uint64_t second{};
+
+        friend bool operator<(
+            const DatasetFileIdentity& left,
+            const DatasetFileIdentity& right) noexcept
+        {
+            return left.first < right.first
+                || (left.first == right.first && left.second < right.second);
+        }
+    };
+
+    std::optional<DatasetFileIdentity> dataset_file_identity(
+        const std::filesystem::path& path) noexcept;
+}
+
+#endif

--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -172,7 +172,7 @@ namespace chess
         KNB = KING_SQUARES,
     };
 
-    inline Square make_square(File f, Rank r) {
+    constexpr Square make_square(File f, Rank r) {
         return Square(std::uint8_t(File::FILE_NB) * std::uint8_t(r) + std::uint8_t(f));
     }
 
@@ -199,6 +199,7 @@ namespace chess
     ENABLE_INCR_OPERATORS_ON(File);
     ENABLE_INCR_OPERATORS_ON(Rank);
     ENABLE_INCR_OPERATORS_ON(PieceType);
+    #undef ENABLE_INCR_OPERATORS_ON
 
     enum struct MoveType : std::uint8_t
     {
@@ -370,8 +371,13 @@ namespace chess
             m_sideToMove(Color::White),
             m_epSquare(Square::NB),
             m_castlingRights(CastlingRights::All),
+            m_castlingRookOrigins{
+                make_square(File::FILE_H, Rank::RANK_1),
+                make_square(File::FILE_A, Rank::RANK_1),
+                make_square(File::FILE_H, Rank::RANK_8),
+                make_square(File::FILE_A, Rank::RANK_8)},
             m_rule50Counter(0),
-            m_ply(0)
+            m_fullmove(1)
         {
         }
 
@@ -380,8 +386,13 @@ namespace chess
             m_sideToMove(sideToMove),
             m_epSquare(epSquare),
             m_castlingRights(castlingRights),
+            m_castlingRookOrigins{
+                make_square(File::FILE_H, Rank::RANK_1),
+                make_square(File::FILE_A, Rank::RANK_1),
+                make_square(File::FILE_H, Rank::RANK_8),
+                make_square(File::FILE_A, Rank::RANK_8)},
             m_rule50Counter(0),
-            m_ply(0)
+            m_fullmove(1)
         {
         }
 
@@ -405,19 +416,40 @@ namespace chess
             m_castlingRights = rights;
         }
 
-        constexpr void setRule50Counter(std::uint8_t v)
+        [[nodiscard]] constexpr CastlingRights castlingRights() const
+        {
+            return m_castlingRights;
+        }
+
+        constexpr void setCastlingRookOrigin(std::size_t index, Square square)
+        {
+            if (index >= m_castlingRookOrigins.size())
+                throw std::invalid_argument("castling-rook origin index is outside its domain");
+            m_castlingRookOrigins[index] = square;
+        }
+
+        [[nodiscard]] constexpr Square castlingRookOrigin(std::size_t index) const
+        {
+            if (index >= m_castlingRookOrigins.size())
+                throw std::invalid_argument("castling-rook origin index is outside its domain");
+            return m_castlingRookOrigins[index];
+        }
+
+        constexpr void setRule50Counter(std::uint16_t v)
         {
             m_rule50Counter = v;
         }
 
-        constexpr void setPly(std::uint16_t ply)
+        constexpr void setPly(std::uint32_t ply)
         {
-            m_ply = ply;
+            m_fullmove = static_cast<std::uint32_t>((std::uint64_t(ply) + 1) / 2);
         }
 
-        inline void setFullMove(std::uint16_t hm)
+        inline void setFullMove(std::uint32_t fullmove)
         {
-            m_ply = 2 * hm - 1 + (m_sideToMove == Color::Black);
+            if (fullmove == 0)
+                throw std::invalid_argument("fullmove number must be positive");
+            m_fullmove = fullmove;
         }
 
         [[nodiscard]] constexpr Color sideToMove() const
@@ -425,29 +457,29 @@ namespace chess
             return m_sideToMove;
         }
 
-        [[nodiscard]] inline std::uint8_t rule50Counter() const
+        [[nodiscard]] inline std::uint16_t rule50Counter() const
         {
             return m_rule50Counter;
         }
 
-        [[nodiscard]] inline std::uint16_t ply() const
+        [[nodiscard]] inline std::uint64_t ply() const
         {
-            return m_ply;
+            return 2ULL * m_fullmove - 1
+                + static_cast<std::uint64_t>(m_sideToMove == Color::Black);
         }
 
-        [[nodiscard]] inline std::uint16_t fullMove() const
+        [[nodiscard]] inline std::uint32_t fullMove() const
         {
-            return (m_ply + 1) / 2;
+            return m_fullmove;
         }
 
     protected:
         Color m_sideToMove;
         Square m_epSquare;
         CastlingRights m_castlingRights;
-        std::uint8_t m_rule50Counter;
-        std::uint16_t m_ply;
-
-        static_assert(sizeof(Color) + sizeof(Square) + sizeof(CastlingRights) + sizeof(std::uint8_t) == 4);
+        std::array<Square, 4> m_castlingRookOrigins;
+        std::uint16_t m_rule50Counter;
+        std::uint32_t m_fullmove;
     };
 
 }
@@ -810,14 +842,26 @@ namespace bin
         }
     }
 
+    enum TrainingDataFlags : std::uint32_t
+    {
+        NoTrainingDataFlags = 0,
+        TrainingDataAtomic960 = 1U << 0
+    };
+
     struct TrainingDataEntry
     {
         chess::Position pos;
         chess::Move move;
-        std::int16_t score;
-        std::uint16_t ply;
-        std::int16_t result;
+        std::int32_t score{};
+        std::uint32_t ply{};
+        std::int8_t result{};
+        std::uint32_t flags{NoTrainingDataFlags};
     };
+
+    static_assert(sizeof(decltype(TrainingDataEntry::score)) == 4);
+    static_assert(sizeof(decltype(TrainingDataEntry::ply)) == 4);
+    static_assert(sizeof(decltype(chess::Position{}.rule50Counter())) == 2);
+    static_assert(sizeof(decltype(chess::Position{}.fullMove())) == 4);
 
     inline void validate_training_move(const chess::Position& pos, const chess::Move& move)
     {

--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -295,7 +295,7 @@ namespace chess
             m_pieces{},
             m_pocketCount{},
             m_pieceCount{},
-            m_kings{}
+            m_kings{Square::NB, Square::NB}
         {
             std::fill_n(m_pieces, static_cast<uint8_t>(Square::NB), Piece::None);
         }

--- a/lib/nnue_training_data_stream.h
+++ b/lib/nnue_training_data_stream.h
@@ -2,9 +2,12 @@
 #define _SFEN_STREAM_H_
 
 #include "nnue_training_data_formats.h"
+#include "atomic_bin_v2_training_data.h"
 
 #include <optional>
+#include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <memory>
 
@@ -34,6 +37,11 @@ namespace training_data {
         {
             return filename + "." + ext;
         }
+    }
+
+    static bool is_atomic_bin_v2_manifest(const std::string& filename)
+    {
+        return ends_with(filename, ".atbin.manifest.json");
     }
 
     struct BasicSfenInputStream
@@ -131,10 +139,91 @@ namespace training_data {
         std::uint64_t m_record_index{0};
     };
 
+    struct AtomicBinV2InputStream : BasicSfenInputStream
+    {
+        AtomicBinV2InputStream(
+            const std::string& manifest_filename,
+            bool cyclic,
+            std::function<bool(const TrainingDataEntry&)> skipPredicate) :
+            m_cyclic(cyclic),
+            m_skipPredicate(std::move(skipPredicate))
+        {
+            Stockfish::Data::DataResult opened =
+                Stockfish::Data::AtomicBinV2DatasetReader::open(
+                    std::filesystem::u8path(manifest_filename),
+                    m_reader);
+            if (!opened)
+                throw std::invalid_argument(
+                    "cannot open Atomic BIN V2 manifest: " + opened.message);
+
+            const auto& options = m_reader->manifest().options;
+            std::clog
+                << "Atomic BIN V2 manifest policy: use_nnue=pure eval_limit=" << options.evalLimit
+                << " filter_captures=" << (options.filterCaptures ? "true" : "false")
+                << " filter_promotions=" << (options.filterPromotions ? "true" : "false")
+                << " filter_checks=" << (options.filterChecks ? "true" : "false")
+                << '\n';
+        }
+
+        std::optional<TrainingDataEntry> next() override
+        {
+            bool rewound_once = false;
+            for (;;)
+            {
+                Stockfish::Data::AtomicBinV2DecodedRecord decoded{};
+                bool has_record = false;
+                Stockfish::Data::DataResult read = m_reader->next(decoded, has_record);
+                if (!read)
+                    throw std::invalid_argument(
+                        "invalid Atomic BIN V2 dataset: " + read.message);
+
+                if (has_record)
+                {
+                    TrainingDataEntry entry =
+                        atomic_bin_v2::to_training_data_entry(decoded);
+                    if (!m_skipPredicate || !m_skipPredicate(entry))
+                        return entry;
+                    continue;
+                }
+
+                if (m_cyclic && !rewound_once)
+                {
+                    Stockfish::Data::DataResult rewound = m_reader->rewind();
+                    if (!rewound)
+                        throw std::invalid_argument(
+                            "cannot rewind Atomic BIN V2 dataset: " + rewound.message);
+                    rewound_once = true;
+                    continue;
+                }
+
+                m_eof = true;
+                return std::nullopt;
+            }
+        }
+
+        bool eof() const override
+        {
+            return m_eof;
+        }
+
+    private:
+        std::unique_ptr<Stockfish::Data::AtomicBinV2DatasetReader> m_reader;
+        bool m_eof{false};
+        bool m_cyclic;
+        std::function<bool(const TrainingDataEntry&)> m_skipPredicate;
+    };
+
     inline std::unique_ptr<BasicSfenInputStream> open_sfen_input_file(const std::string& filename, bool cyclic, std::function<bool(const TrainingDataEntry&)> skipPredicate = nullptr)
     {
         if (has_extension(filename, BinSfenInputStream::extension))
             return std::make_unique<BinSfenInputStream>(filename, cyclic, std::move(skipPredicate));
+
+        if (is_atomic_bin_v2_manifest(filename))
+            return std::make_unique<AtomicBinV2InputStream>(filename, cyclic, std::move(skipPredicate));
+
+        if (has_extension(filename, "atbin"))
+            throw std::invalid_argument(
+                "Atomic BIN V2 raw shards are not dataset entrypoints; use the .atbin.manifest.json sidecar");
 
         return nullptr;
     }
@@ -142,10 +231,8 @@ namespace training_data {
     inline std::unique_ptr<BasicSfenInputStream> open_sfen_input_file_parallel(int concurrency, const std::string& filename, bool cyclic, std::function<bool(const TrainingDataEntry&)> skipPredicate = nullptr)
     {
         // TODO (low priority): optimize and parallelize .bin reading.
-        if (has_extension(filename, BinSfenInputStream::extension))
-            return std::make_unique<BinSfenInputStream>(filename, cyclic, std::move(skipPredicate));
-
-        return nullptr;
+        (void) concurrency;
+        return open_sfen_input_file(filename, cyclic, std::move(skipPredicate));
     }
 }
 

--- a/lib/nnue_training_data_stream.h
+++ b/lib/nnue_training_data_stream.h
@@ -158,7 +158,7 @@ namespace training_data {
 
             const auto& options = m_reader->manifest().options;
             std::clog
-                << "Atomic BIN V2 manifest policy: use_nnue=pure eval_limit=" << options.evalLimit
+                << "Atomic BIN V2 manifest policy: eval_limit=" << options.evalLimit
                 << " filter_captures=" << (options.filterCaptures ? "true" : "false")
                 << " filter_promotions=" << (options.filterPromotions ? "true" : "false")
                 << " filter_checks=" << (options.filterChecks ? "true" : "false")

--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -93,18 +93,45 @@ def _bind_atomic_training_data_schema(library):
 get_atomic_training_data_schema_json = _bind_atomic_training_data_schema(dll)
 
 
-def atomic_training_data_schema():
-    """Return the native loader's read-only Atomic dataset capabilities."""
-    payload = get_atomic_training_data_schema_json()
+def _bind_atomic_training_data_schemas(library):
+    try:
+        function = library.get_atomic_training_data_schemas_json
+    except AttributeError as error:
+        raise RuntimeError(
+            'Training data loader does not expose the plural Atomic schema handshake; rebuild the native library'
+        ) from error
+    function.restype = ctypes.c_char_p
+    function.argtypes = []
+    return function
+
+
+get_atomic_training_data_schemas_json = _bind_atomic_training_data_schemas(dll)
+
+
+def _decode_schema_payload(payload, label):
     if payload is None:
-        raise RuntimeError('Native data loader returned no Atomic training-data schema')
+        raise RuntimeError('Native data loader returned no {}'.format(label))
     try:
         document = json.loads(payload.decode('utf-8'))
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
-        raise RuntimeError('Native data loader returned invalid Atomic training-data schema JSON') from error
+        raise RuntimeError('Native data loader returned invalid {} JSON'.format(label)) from error
     if not isinstance(document, dict):
-        raise RuntimeError('Native Atomic training-data schema must be a JSON object')
+        raise RuntimeError('Native {} must be a JSON object'.format(label))
     return document
+
+
+def atomic_training_data_schema():
+    """Return the byte-stable Legacy Atomic V1 schema handshake."""
+    return _decode_schema_payload(
+        get_atomic_training_data_schema_json(),
+        'Atomic training-data schema')
+
+
+def atomic_training_data_schemas():
+    """Return the additive Legacy V1 plus manifest-only Atomic BIN V2 capabilities."""
+    return _decode_schema_payload(
+        get_atomic_training_data_schemas_json(),
+        'Atomic training-data schemas')
 
 
 def _bounded_integer(name, value, minimum, maximum):
@@ -133,7 +160,8 @@ class TrainingDataProvider:
         random_fen_skipping=0,
         device='cpu',
         seed=None,
-        get_error=None):
+        get_error=None,
+        get_creation_error=None):
 
         self.feature_set = feature_set.encode('utf-8')
         self.create_stream = create_stream
@@ -149,6 +177,7 @@ class TrainingDataProvider:
         self.seed = None if seed is None else _bounded_integer('seed', seed, 0, UINT64_MAX)
         self.device = device
         self.get_error = get_error
+        self.get_creation_error = get_creation_error
 
         stream_arguments = [
             self.feature_set,
@@ -163,6 +192,11 @@ class TrainingDataProvider:
             stream_arguments.append(self.seed)
         self.stream = self.create_stream(*stream_arguments)
         if not self.stream:
+            native_error = self.get_creation_error() if self.get_creation_error is not None else None
+            if native_error:
+                if isinstance(native_error, bytes):
+                    native_error = native_error.decode('utf-8', errors='replace')
+                raise RuntimeError('Native data loader rejected the stream: {}'.format(native_error))
             raise RuntimeError('Native data loader rejected the stream configuration')
 
     def __iter__(self):
@@ -213,6 +247,12 @@ create_sparse_batch_stream_with_seed.argtypes = [
     ctypes.c_int,     # random_fen_skipping
     ctypes.c_uint64   # deterministic random-skip seed
 ]
+get_sparse_batch_stream_creation_error = dll.get_sparse_batch_stream_creation_error
+get_sparse_batch_stream_creation_error.restype = ctypes.c_char_p
+get_sparse_batch_stream_creation_error.argtypes = []
+validate_training_validation_data_paths_native = dll.validate_training_validation_data_paths
+validate_training_validation_data_paths_native.restype = ctypes.c_char_p
+validate_training_validation_data_paths_native.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
 destroy_sparse_batch_stream = dll.destroy_sparse_batch_stream
 destroy_sparse_batch_stream.argtypes = [ctypes.c_void_p]
 destroy_sparse_batch_stream.restype = None
@@ -226,6 +266,15 @@ get_sparse_batch_stream_error.argtypes = [ctypes.c_void_p]
 destroy_sparse_batch = dll.destroy_sparse_batch
 destroy_sparse_batch.argtypes = [SparseBatchPtr]
 destroy_sparse_batch.restype = None
+
+
+def validate_training_validation_data_paths(training_path, validation_path):
+    """Reject V2 train/validation manifests sharing a shard hash or file identity."""
+    error = validate_training_validation_data_paths_native(
+        os.fsencode(training_path),
+        os.fsencode(validation_path))
+    if error:
+        raise ValueError(error.decode('utf-8', errors='replace'))
 
 
 class SparseBatchProvider(TrainingDataProvider):
@@ -244,7 +293,8 @@ class SparseBatchProvider(TrainingDataProvider):
             random_fen_skipping,
             device,
             seed,
-            get_sparse_batch_stream_error)
+            get_sparse_batch_stream_error,
+            get_sparse_batch_stream_creation_error)
 
 class SparseBatchDataset(torch.utils.data.IterableDataset):
   def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False, random_fen_skipping=0, device='cpu', seed=0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import base64
 import hashlib
+import json
 import os
+import struct
 
 import pytest
 
@@ -40,3 +42,94 @@ def atomic_legacy_32(tmp_path):
     path = tmp_path / 'atomic-legacy-32.bin'
     path.write_bytes(data)
     return path
+
+
+@pytest.fixture
+def atomic_v2_manifest(tmp_path):
+    data_schema = '0352b036f2a140c609e3eb9c9d635dc553e8d77253d8faa92437390f5cf93cb6'
+    manifest_schema = '83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42'
+    record = bytes.fromhex(
+        '2453364211111111'
+        '00000000000000000000000000000000'
+        '777777778ab99ca8'
+        '000f07003f38ff00'
+        '0000010000000000'
+        '85ffffff0c0700002a000000ff000000'
+    )
+    header = struct.pack(
+        '<8sHHIII32sQ32s',
+        b'ATBINV2\0',
+        2,
+        96,
+        0x01020304,
+        64,
+        0,
+        bytes.fromhex(data_schema),
+        1,
+        bytes(32),
+    )
+    payload = header + record
+    root = tmp_path / 'atomic-v2-\N{LATIN SMALL LETTER N WITH TILDE}'
+    root.mkdir()
+    shard = root / 'datos-\N{LATIN SMALL LETTER N WITH TILDE}.atbin'
+    shard.write_bytes(payload)
+    manifest = {
+        'manifest_version': 1,
+        'manifest_schema_sha256': manifest_schema,
+        'data_schema_sha256': data_schema,
+        'format': 'atomic-bin-v2',
+        'engine': {
+            'commit': '1e64c6f16e8c327be6ee5e3de57ed54d1079f060',
+            'version': 'Atomic-Stockfish Python trainer fixture',
+        },
+        'network': {'file': 'atomic.nnue', 'sha256': '1' * 64},
+        'book': {'kind': 'builtin-startpos', 'file': None, 'sha256': None},
+        'generation': {
+            'resolved_seed': '20260713',
+            'atomic960': False,
+            'threads': 1,
+            'hash_mb': '16',
+            'use_nnue': 'pure',
+            'options': {
+                'search_depth_min': 3,
+                'search_depth_max': 3,
+                'nodes': '0',
+                'requested_records': '1',
+                'records_per_shard': '1',
+                'eval_limit': 32000,
+                'eval_diff_limit': 64000,
+                'random_move_min_ply': 1,
+                'random_move_max_ply': 24,
+                'random_move_count': 5,
+                'random_move_like_apery': 0,
+                'random_multi_pv': 5,
+                'random_multi_pv_diff': 100,
+                'random_multi_pv_depth': 3,
+                'write_min_ply': 5,
+                'write_max_ply': 400,
+                'keep_draws': '0.5',
+                'adjudicate_draws_by_score': False,
+                'adjudicate_insufficient': False,
+                'filter_captures': True,
+                'filter_checks': False,
+                'filter_promotions': True,
+                'random_file_name': False,
+                'set_recommended_uci_options_seen': True,
+            },
+        },
+        'statistics': {'records': '1', 'draws': '0'},
+        'shards': [{
+            'index': 0,
+            'file': shard.name,
+            'records': '1',
+            'bytes': str(len(payload)),
+            'sha256': hashlib.sha256(payload).hexdigest(),
+        }],
+    }
+    manifest_path = shard.with_name(shard.name + '.manifest.json')
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, separators=(',', ':')) + '\n',
+        encoding='utf-8',
+        newline='\n',
+    )
+    return manifest_path

--- a/tests/native_loader_tests.cpp
+++ b/tests/native_loader_tests.cpp
@@ -7,12 +7,225 @@
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <string>
+#include <vector>
 
 #include "../training_data_loader.cpp"
+#include "../external/Atomic-Stockfish/src/atomic_init.h"
+#include "../external/Atomic-Stockfish/src/data/sha256.h"
 
 using bin::TrainingDataEntry;
 using namespace chess;
+namespace AtomicData = Stockfish::Data;
+
+struct TemporaryDirectory
+{
+    std::filesystem::path path;
+
+    explicit TemporaryDirectory(const std::string& label)
+    {
+        const auto nonce = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        path = std::filesystem::temp_directory_path()
+            / ("atomic-trainer-v2-" + label + "-" + std::to_string(nonce));
+        assert(std::filesystem::create_directories(path));
+    }
+
+    ~TemporaryDirectory()
+    {
+        std::error_code error;
+        std::filesystem::remove_all(path, error);
+    }
+};
+
+struct V2Dataset
+{
+    std::filesystem::path shard;
+    std::filesystem::path manifest;
+    AtomicData::AtomicBinV2Manifest metadata;
+};
+
+struct V2MultiDataset
+{
+    std::vector<std::filesystem::path> shards;
+    std::filesystem::path manifest;
+    AtomicData::AtomicBinV2Manifest metadata;
+};
+
+static std::string utf8_path(const std::filesystem::path& path)
+{
+    return path.u8string();
+}
+
+static AtomicData::TrainingDataSample ordinary_v2_sample()
+{
+    AtomicData::TrainingDataSample sample;
+    sample.fen = "7k/8/8/8/8/8/4P3/K7 w - - 32767 100000";
+    sample.move = Stockfish::Move(Stockfish::SQ_E2, Stockfish::SQ_E3);
+    sample.score = std::numeric_limits<std::int32_t>::max();
+    sample.ply = std::numeric_limits<std::uint32_t>::max();
+    sample.result = -1;
+    return sample;
+}
+
+static AtomicData::AtomicBinV2Manifest v2_metadata(
+    const std::filesystem::path& manifest_path,
+    const std::filesystem::path& shard_path,
+    std::string sha256,
+    const AtomicData::TrainingDataSample& sample)
+{
+    AtomicData::AtomicBinV2Manifest manifest;
+    manifest.manifestPath = manifest_path;
+    manifest.engineCommit = "1e64c6f16e8c327be6ee5e3de57ed54d1079f060";
+    manifest.engineVersion = "Atomic-Stockfish trainer integration test";
+    manifest.networkPath = manifest_path.parent_path() / "atomic.nnue";
+    manifest.networkSha256 = std::string(64, '1');
+    manifest.resolvedSeed = 20260713;
+    manifest.atomic960 = bool(sample.flags & AtomicData::TRAINING_DATA_CHESS960);
+    manifest.threads = 1;
+    manifest.hashMb = 16;
+    manifest.options.searchDepthMin = 3;
+    manifest.options.searchDepthMax = 3;
+    manifest.options.evalLimit = 32000;
+    manifest.options.evalDiffLimit = 64000;
+    manifest.options.randomMoveMinPly = 1;
+    manifest.options.randomMoveMaxPly = 24;
+    manifest.options.randomMoveCount = 5;
+    manifest.options.randomMultiPv = 5;
+    manifest.options.randomMultiPvDiff = 100;
+    manifest.options.randomMultiPvDepth = 3;
+    manifest.options.writeMinPly = 1;
+    manifest.options.writeMaxPly = 4096;
+    manifest.options.requestedRecords = 1;
+    manifest.options.recordsPerShard = 1;
+    manifest.options.keepDraws = "0.5";
+    manifest.options.filterCaptures = true;
+    manifest.options.filterPromotions = true;
+    manifest.options.filterChecks = false;
+    manifest.records = 1;
+    manifest.draws = sample.result == 0 ? 1 : 0;
+
+    AtomicData::AtomicBinV2ManifestShard shard;
+    shard.path = shard_path;
+    shard.records = 1;
+    shard.bytes = AtomicData::AtomicBinV2HeaderSize + AtomicData::AtomicBinV2RecordSize;
+    shard.sha256 = std::move(sha256);
+    manifest.shards.push_back(std::move(shard));
+    return manifest;
+}
+
+static bool write_v2_manifest(const AtomicData::AtomicBinV2Manifest& manifest)
+{
+    std::string json;
+    if (!AtomicData::render_atomic_bin_v2_manifest(manifest, json))
+        return false;
+    std::ofstream output(manifest.manifestPath, std::ios::binary | std::ios::trunc);
+    output.write(json.data(), static_cast<std::streamsize>(json.size()));
+    return bool(output);
+}
+
+static V2Dataset create_v2_dataset(
+    const std::filesystem::path& directory,
+    const std::string& stem,
+    const AtomicData::TrainingDataSample& sample)
+{
+    V2Dataset dataset;
+    dataset.shard = directory / (stem + ".atbin");
+    dataset.manifest = directory / (stem + ".atbin.manifest.json");
+
+    AtomicData::AtomicBinV2Header header{};
+    AtomicData::AtomicBinV2Record record{};
+    assert(AtomicData::encode_atomic_bin_v2_header(1, header));
+    assert(AtomicData::encode_atomic_bin_v2(sample, record));
+    {
+        std::ofstream output(dataset.shard, std::ios::binary | std::ios::trunc);
+        output.write(
+            reinterpret_cast<const char*>(header.data()),
+            static_cast<std::streamsize>(header.size()));
+        output.write(
+            reinterpret_cast<const char*>(record.data()),
+            static_cast<std::streamsize>(record.size()));
+        assert(output);
+    }
+
+    std::string sha256;
+    Stockfish::u64 size = 0;
+    assert(AtomicData::sha256_file(dataset.shard, sha256, size));
+    dataset.metadata = v2_metadata(dataset.manifest, dataset.shard, sha256, sample);
+    assert(write_v2_manifest(dataset.metadata));
+    return dataset;
+}
+
+static V2MultiDataset create_v2_multishard_dataset(
+    const std::filesystem::path& directory,
+    const std::string& stem,
+    const std::vector<std::vector<AtomicData::TrainingDataSample>>& shard_samples)
+{
+    assert(shard_samples.size() >= 2);
+    assert(!shard_samples.front().empty());
+
+    V2MultiDataset dataset;
+    dataset.manifest = directory / (stem + ".atbin.manifest.json");
+    dataset.metadata = v2_metadata(
+        dataset.manifest,
+        directory / (stem + ".atbin"),
+        std::string(64, '0'),
+        shard_samples.front().front());
+    dataset.metadata.shards.clear();
+    dataset.metadata.records = 0;
+    dataset.metadata.draws = 0;
+    dataset.metadata.options.recordsPerShard = shard_samples.front().size();
+
+    for (std::size_t shard_index = 0; shard_index < shard_samples.size(); ++shard_index)
+    {
+        const auto& samples = shard_samples[shard_index];
+        assert(!samples.empty());
+        if (shard_index + 1 < shard_samples.size())
+            assert(samples.size() == shard_samples.front().size());
+        else
+            assert(samples.size() <= shard_samples.front().size());
+
+        const auto shard_path = directory
+            / (shard_index == 0
+                ? stem + ".atbin"
+                : stem + "-" + std::to_string(shard_index) + ".atbin");
+        AtomicData::AtomicBinV2Header header{};
+        assert(AtomicData::encode_atomic_bin_v2_header(samples.size(), header));
+        {
+            std::ofstream output(shard_path, std::ios::binary | std::ios::trunc);
+            output.write(
+                reinterpret_cast<const char*>(header.data()),
+                static_cast<std::streamsize>(header.size()));
+            for (const auto& sample : samples)
+            {
+                AtomicData::AtomicBinV2Record record{};
+                assert(AtomicData::encode_atomic_bin_v2(sample, record));
+                output.write(
+                    reinterpret_cast<const char*>(record.data()),
+                    static_cast<std::streamsize>(record.size()));
+                dataset.metadata.draws += sample.result == 0 ? 1 : 0;
+            }
+            assert(output);
+        }
+
+        std::string sha256;
+        Stockfish::u64 size = 0;
+        assert(AtomicData::sha256_file(shard_path, sha256, size));
+        AtomicData::AtomicBinV2ManifestShard shard;
+        shard.path = shard_path;
+        shard.index = shard_index;
+        shard.records = samples.size();
+        shard.bytes = size;
+        shard.sha256 = std::move(sha256);
+        dataset.metadata.shards.push_back(std::move(shard));
+        dataset.metadata.records += samples.size();
+        dataset.shards.push_back(shard_path);
+    }
+
+    dataset.metadata.options.requestedRecords = dataset.metadata.records;
+    assert(write_v2_manifest(dataset.metadata));
+    return dataset;
+}
 
 static Square sq(int file, int rank)
 {
@@ -247,6 +460,371 @@ static void test_atomic_training_data_schema_handshake()
         "{\"schema_sha256\":\"acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1\","
         "\"formats\":{\"legacy-atomic-v1\":{\"read\":true,\"write\":false,"
         "\"record_size\":72}}}");
+
+    const char* schemas_json = get_atomic_training_data_schemas_json();
+    assert(schemas_json != nullptr);
+    assert(std::string(schemas_json) ==
+        "{\"capability_version\":2,\"formats\":{\"legacy-atomic-v1\":{"
+        "\"schema_sha256\":\"acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1\","
+        "\"read\":true,\"write\":false,\"header_size\":0,\"record_size\":72},"
+        "\"atomic-bin-v2\":{\"read\":true,\"write\":false,"
+        "\"entrypoint\":\"manifest\",\"header_size\":96,\"record_size\":64,"
+        "\"schema_sha256\":\"0352b036f2a140c609e3eb9c9d635dc553e8d77253d8faa92437390f5cf93cb6\","
+        "\"manifest_schema_sha256\":\"83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42\"}}}");
+}
+
+static void test_atomic_bin_v2_manifest_only_roundtrip()
+{
+    Stockfish::initialize_atomic_core();
+    TemporaryDirectory temporary("roundtrip");
+    const auto sample = ordinary_v2_sample();
+    const auto dataset = create_v2_dataset(temporary.path, "dataset", sample);
+    const auto manifest = utf8_path(dataset.manifest);
+
+    training_data::AtomicBinV2InputStream input(manifest, false, nullptr);
+    const auto decoded = input.next();
+    assert(decoded.has_value());
+    assert(decoded->score == std::numeric_limits<std::int32_t>::max());
+    assert(decoded->ply == std::numeric_limits<std::uint32_t>::max());
+    assert(decoded->result == -1);
+    assert(decoded->flags == bin::NoTrainingDataFlags);
+    assert(decoded->pos.sideToMove() == Color::White);
+    assert(decoded->pos.rule50Counter() == 32767);
+    assert(decoded->pos.fullMove() == 100000);
+    assert(!input.next().has_value());
+    assert(input.eof());
+
+    training_data::AtomicBinV2InputStream cyclic(manifest, true, nullptr);
+    assert(cyclic.next()->ply == std::numeric_limits<std::uint32_t>::max());
+    assert(cyclic.next()->ply == std::numeric_limits<std::uint32_t>::max());
+
+    const auto raw_shard = utf8_path(dataset.shard);
+    auto* raw = create_sparse_batch_stream_with_seed(
+        "HalfKAv2", 1, raw_shard.c_str(), 1, false, false, 0, 0);
+    assert(raw == nullptr);
+    assert(std::string(get_sparse_batch_stream_creation_error()).find("raw shards")
+        != std::string::npos);
+
+    auto experimental = create_v2_dataset(temporary.path, "experimental", sample);
+    experimental.metadata.options.evalLimit = 3000;
+    experimental.metadata.options.filterCaptures = false;
+    experimental.metadata.options.filterPromotions = false;
+    experimental.metadata.options.filterChecks = true;
+    assert(write_v2_manifest(experimental.metadata));
+    training_data::AtomicBinV2InputStream experimental_input(
+        utf8_path(experimental.manifest),
+        false,
+        nullptr);
+    assert(experimental_input.next().has_value());
+}
+
+static void test_widened_internal_position_boundaries()
+{
+    chess::Position position;
+    position.setRule50Counter(std::numeric_limits<std::uint16_t>::max());
+    position.setFullMove(std::numeric_limits<std::uint32_t>::max());
+    position.setSideToMove(Color::Black);
+
+    assert(position.rule50Counter() == std::numeric_limits<std::uint16_t>::max());
+    assert(position.fullMove() == std::numeric_limits<std::uint32_t>::max());
+    assert(position.ply() == 2ULL * std::numeric_limits<std::uint32_t>::max());
+}
+
+static void test_atomic_bin_v2_atomic960_and_stm_semantics()
+{
+    TemporaryDirectory temporary("atomic960");
+    AtomicData::TrainingDataSample sample;
+    sample.fen = "7k/8/8/8/8/8/8/1RK5 w B - 0 1";
+    sample.move = Stockfish::Move::make<Stockfish::CASTLING>(
+        Stockfish::SQ_C1,
+        Stockfish::SQ_B1);
+    sample.score = -321;
+    sample.ply = 27;
+    sample.result = 1;
+    sample.flags = AtomicData::TRAINING_DATA_CHESS960;
+    const auto dataset = create_v2_dataset(temporary.path, "atomic960", sample);
+
+    training_data::AtomicBinV2InputStream input(utf8_path(dataset.manifest), false, nullptr);
+    const auto decoded = input.next();
+    assert(decoded.has_value());
+    assert(decoded->score == -321);
+    assert(decoded->result == 1);
+    assert(decoded->ply == 27);
+    assert(decoded->flags == bin::TrainingDataAtomic960);
+    assert(decoded->move.type == MoveType::Castle);
+    assert(decoded->move.from == sq(2, 0));
+    assert(decoded->move.to == sq(1, 0));
+    assert(contains(decoded->pos.castlingRights(), CastlingRights::WhiteQueenSide));
+    assert(decoded->pos.castlingRookOrigin(1) == sq(1, 0));
+
+    AtomicData::TrainingDataSample black_sample;
+    black_sample.fen = "7k/4p3/8/8/8/8/8/K7 b - - 0 1";
+    black_sample.move = Stockfish::Move(Stockfish::SQ_E7, Stockfish::SQ_E6);
+    black_sample.score = -444;
+    black_sample.ply = 9;
+    black_sample.result = 1;
+    const auto black_dataset = create_v2_dataset(
+        temporary.path,
+        "black-stm",
+        black_sample);
+    training_data::AtomicBinV2InputStream black_input(
+        utf8_path(black_dataset.manifest),
+        false,
+        nullptr);
+    const auto black_decoded = black_input.next();
+    assert(black_decoded.has_value());
+    assert(black_decoded->pos.sideToMove() == Color::Black);
+    assert(black_decoded->score == -444);
+    assert(black_decoded->result == 1);
+}
+
+struct BatchSequence
+{
+    std::vector<int> batch_sizes;
+    std::vector<float> scores;
+
+    friend bool operator==(const BatchSequence& left, const BatchSequence& right)
+    {
+        return left.batch_sizes == right.batch_sizes && left.scores == right.scores;
+    }
+};
+
+static BatchSequence collect_v2_batches(
+    const std::filesystem::path& manifest,
+    int workers,
+    int batch_size)
+{
+    const auto manifest_path = utf8_path(manifest);
+    auto* stream = create_sparse_batch_stream_with_seed(
+        "HalfKAv2", workers, manifest_path.c_str(), batch_size, false, false, 0, 17);
+    assert(stream != nullptr);
+
+    BatchSequence sequence;
+    while (SparseBatch* batch = fetch_next_sparse_batch(stream))
+    {
+        sequence.batch_sizes.push_back(batch->size);
+        sequence.scores.insert(sequence.scores.end(), batch->score, batch->score + batch->size);
+        destroy_sparse_batch(batch);
+    }
+    assert(get_sparse_batch_stream_error(stream)[0] == '\0');
+    destroy_sparse_batch_stream(stream);
+    return sequence;
+}
+
+static void test_atomic_bin_v2_multishard_eof_partial_and_determinism()
+{
+    TemporaryDirectory temporary("multishard");
+    std::vector<AtomicData::TrainingDataSample> samples;
+    for (int index = 0; index < 5; ++index)
+    {
+        auto sample = ordinary_v2_sample();
+        sample.score = 100 + index;
+        sample.ply = 200 + index;
+        samples.push_back(std::move(sample));
+    }
+    const auto dataset = create_v2_multishard_dataset(
+        temporary.path,
+        "multi",
+        {{samples.begin(), samples.begin() + 3}, {samples.begin() + 3, samples.end()}});
+
+    const auto single_worker = collect_v2_batches(dataset.manifest, 1, 3);
+    const auto four_workers = collect_v2_batches(dataset.manifest, 4, 3);
+    assert(single_worker == four_workers);
+    assert(single_worker.batch_sizes == std::vector<int>({3, 2}));
+    assert(single_worker.scores == std::vector<float>({100, 101, 102, 103, 104}));
+
+    training_data::AtomicBinV2InputStream cyclic(
+        utf8_path(dataset.manifest),
+        true,
+        nullptr);
+    for (int index = 0; index < 5; ++index)
+        assert(cyclic.next()->score == 100 + index);
+    assert(cyclic.next()->score == 100);
+}
+
+static void assert_sparse_batches_equal(const SparseBatch& left, const SparseBatch& right)
+{
+    assert(left.num_inputs == right.num_inputs);
+    assert(left.size == right.size);
+    assert(left.num_active_white_features == right.num_active_white_features);
+    assert(left.num_active_black_features == right.num_active_black_features);
+    assert(left.max_active_features == right.max_active_features);
+
+    for (int index = 0; index < left.size; ++index)
+    {
+        assert(left.is_white[index] == right.is_white[index]);
+        assert(left.outcome[index] == right.outcome[index]);
+        assert(left.score[index] == right.score[index]);
+        assert(left.psqt_indices[index] == right.psqt_indices[index]);
+        assert(left.layer_stack_indices[index] == right.layer_stack_indices[index]);
+    }
+    for (int index = 0; index < left.size * left.max_active_features; ++index)
+    {
+        assert(left.white[index] == right.white[index]);
+        assert(left.black[index] == right.black[index]);
+        assert(left.white_values[index] == right.white_values[index]);
+        assert(left.black_values[index] == right.black_values[index]);
+    }
+}
+
+static void test_atomic_bin_v2_halfkav2_sparse_parity_with_legacy72()
+{
+    TemporaryDirectory temporary("sparse-parity");
+    auto legacy_record = valid_legacy_record();
+    legacy_record.score = -77;
+    legacy_record.gamePly = 12;
+    legacy_record.game_result = 1;
+    const auto legacy_path = temporary.path / "same-position.bin";
+    {
+        std::ofstream output(legacy_path, std::ios::binary | std::ios::trunc);
+        output.write(
+            reinterpret_cast<const char*>(&legacy_record),
+            static_cast<std::streamsize>(sizeof(legacy_record)));
+        assert(output);
+    }
+
+    AtomicData::TrainingDataSample v2_sample;
+    v2_sample.fen = "4k3/8/8/8/8/8/P7/4K3 w - - 0 1";
+    v2_sample.move = Stockfish::Move(Stockfish::SQ_A2, Stockfish::SQ_A3);
+    v2_sample.score = -77;
+    v2_sample.ply = 12;
+    v2_sample.result = 1;
+    const auto v2_dataset = create_v2_dataset(temporary.path, "same-position", v2_sample);
+
+    const auto legacy_filename = utf8_path(legacy_path);
+    const auto v2_filename = utf8_path(v2_dataset.manifest);
+    auto* legacy_stream = create_sparse_batch_stream_with_seed(
+        "HalfKAv2", 1, legacy_filename.c_str(), 1, false, false, 0, 0);
+    auto* v2_stream = create_sparse_batch_stream_with_seed(
+        "HalfKAv2", 1, v2_filename.c_str(), 1, false, false, 0, 0);
+    assert(legacy_stream != nullptr);
+    assert(v2_stream != nullptr);
+
+    SparseBatch* legacy_batch = fetch_next_sparse_batch(legacy_stream);
+    SparseBatch* v2_batch = fetch_next_sparse_batch(v2_stream);
+    assert(legacy_batch != nullptr);
+    assert(v2_batch != nullptr);
+    assert_sparse_batches_equal(*legacy_batch, *v2_batch);
+    destroy_sparse_batch(legacy_batch);
+    destroy_sparse_batch(v2_batch);
+
+    assert(fetch_next_sparse_batch(legacy_stream) == nullptr);
+    assert(fetch_next_sparse_batch(v2_stream) == nullptr);
+    assert(get_sparse_batch_stream_error(legacy_stream)[0] == '\0');
+    assert(get_sparse_batch_stream_error(v2_stream)[0] == '\0');
+    destroy_sparse_batch_stream(legacy_stream);
+    destroy_sparse_batch_stream(v2_stream);
+}
+
+static void test_atomic_bin_v2_bypasses_legacy_smart_filter()
+{
+    TemporaryDirectory temporary("filter-policy");
+    AtomicData::TrainingDataSample sample;
+    sample.fen = "7k/8/8/8/8/3p4/4P3/K7 w - - 0 1";
+    sample.move = Stockfish::Move(Stockfish::SQ_E2, Stockfish::SQ_D3);
+    sample.score = 17;
+    sample.ply = 3;
+    sample.result = 1;
+    const auto dataset = create_v2_dataset(temporary.path, "capture", sample);
+    const auto manifest = utf8_path(dataset.manifest);
+
+    auto* stream = create_sparse_batch_stream_with_seed(
+        "HalfKAv2", 2, manifest.c_str(), 1, false, true, 0, 7);
+    assert(stream != nullptr);
+    SparseBatch* batch = fetch_next_sparse_batch(stream);
+    assert(batch != nullptr);
+    assert(batch->size == 1);
+    assert(batch->score[0] == 17.0f);
+    destroy_sparse_batch(batch);
+    assert(fetch_next_sparse_batch(stream) == nullptr);
+    assert(get_sparse_batch_stream_error(stream)[0] == '\0');
+    destroy_sparse_batch_stream(stream);
+}
+
+static void test_atomic_bin_v2_corruption_and_schema_fail_closed()
+{
+    TemporaryDirectory temporary("fail-closed");
+    const auto sample = ordinary_v2_sample();
+
+    auto corrupt = create_v2_dataset(temporary.path, "corrupt", sample);
+    {
+        std::fstream shard(corrupt.shard, std::ios::in | std::ios::out | std::ios::binary);
+        assert(shard);
+        shard.seekp(-1, std::ios::end);
+        const char changed = '\x01';
+        shard.write(&changed, 1);
+        assert(shard);
+    }
+    const auto corrupt_manifest = utf8_path(corrupt.manifest);
+    auto* stream = create_sparse_batch_stream_with_seed(
+        "HalfKAv2", 1, corrupt_manifest.c_str(), 1, false, false, 0, 0);
+    if (stream != nullptr)
+    {
+        assert(fetch_next_sparse_batch(stream) == nullptr);
+        assert(std::string(get_sparse_batch_stream_error(stream)).find("SHA-256")
+            != std::string::npos);
+        destroy_sparse_batch_stream(stream);
+    }
+    else
+        assert(std::string(get_sparse_batch_stream_creation_error()).find("SHA-256")
+            != std::string::npos);
+
+    auto schema = create_v2_dataset(temporary.path, "schema", sample);
+    std::ifstream input(schema.manifest, std::ios::binary);
+    std::string json((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    input.close();
+    const auto marker = json.find(AtomicData::AtomicBinV2SchemaSha256Hex);
+    assert(marker != std::string::npos);
+    json[marker] = json[marker] == '0' ? '1' : '0';
+    {
+        std::ofstream output(schema.manifest, std::ios::binary | std::ios::trunc);
+        output.write(json.data(), static_cast<std::streamsize>(json.size()));
+        assert(output);
+    }
+    const auto schema_manifest = utf8_path(schema.manifest);
+    assert(create_sparse_batch_stream_with_seed(
+        "HalfKAv2", 1, schema_manifest.c_str(), 1, false, false, 0, 0) == nullptr);
+    assert(std::string(get_sparse_batch_stream_creation_error()).find("schema")
+        != std::string::npos);
+}
+
+static void test_atomic_bin_v2_train_validation_overlap()
+{
+    TemporaryDirectory temporary("overlap");
+    const auto sample = ordinary_v2_sample();
+    const auto train = create_v2_dataset(temporary.path, "train", sample);
+    const auto copied = create_v2_dataset(temporary.path, "copied", sample);
+
+    const auto train_manifest = utf8_path(train.manifest);
+    const auto copied_manifest = utf8_path(copied.manifest);
+    const char* overlap = validate_training_validation_data_paths(
+        train_manifest.c_str(),
+        copied_manifest.c_str());
+    assert(overlap != nullptr);
+    assert(std::string(overlap).find("overlap") != std::string::npos);
+
+    auto different_sample = sample;
+    different_sample.score -= 1;
+    const auto distinct = create_v2_dataset(temporary.path, "distinct", different_sample);
+    const auto distinct_manifest = utf8_path(distinct.manifest);
+    assert(validate_training_validation_data_paths(
+        train_manifest.c_str(),
+        distinct_manifest.c_str()) == nullptr);
+
+    const auto hardlink_shard = temporary.path / "hardlink.atbin";
+    std::filesystem::create_hard_link(train.shard, hardlink_shard);
+    auto hardlink_metadata = v2_metadata(
+        temporary.path / "hardlink.atbin.manifest.json",
+        hardlink_shard,
+        std::string(64, '2'),
+        sample);
+    assert(write_v2_manifest(hardlink_metadata));
+    const auto hardlink_manifest = utf8_path(hardlink_metadata.manifestPath);
+    overlap = validate_training_validation_data_paths(
+        train_manifest.c_str(),
+        hardlink_manifest.c_str());
+    assert(overlap != nullptr);
+    assert(std::string(overlap).find("overlap") != std::string::npos);
 }
 
 static void test_corrupt_full_size_records_fail_closed()
@@ -317,6 +895,14 @@ int main()
     test_seeded_random_skipping();
     test_c_api_validation();
     test_atomic_training_data_schema_handshake();
+    test_atomic_bin_v2_manifest_only_roundtrip();
+    test_widened_internal_position_boundaries();
+    test_atomic_bin_v2_atomic960_and_stm_semantics();
+    test_atomic_bin_v2_multishard_eof_partial_and_determinism();
+    test_atomic_bin_v2_halfkav2_sparse_parity_with_legacy72();
+    test_atomic_bin_v2_bypasses_legacy_smart_filter();
+    test_atomic_bin_v2_corruption_and_schema_fail_closed();
+    test_atomic_bin_v2_train_validation_overlap();
     test_corrupt_full_size_records_fail_closed();
     return 0;
 }

--- a/tests/native_loader_tests.cpp
+++ b/tests/native_loader_tests.cpp
@@ -521,6 +521,8 @@ static void test_atomic_bin_v2_manifest_only_roundtrip()
 static void test_widened_internal_position_boundaries()
 {
     chess::Position position;
+    assert(position.kingSquare(Color::White) == chess::Square::NB);
+    assert(position.kingSquare(Color::Black) == chess::Square::NB);
     position.setRule50Counter(std::numeric_limits<std::uint16_t>::max());
     position.setFullMove(std::numeric_limits<std::uint32_t>::max());
     position.setSideToMove(Color::Black);
@@ -528,6 +530,32 @@ static void test_widened_internal_position_boundaries()
     assert(position.rule50Counter() == std::numeric_limits<std::uint16_t>::max());
     assert(position.fullMove() == std::numeric_limits<std::uint32_t>::max());
     assert(position.ply() == 2ULL * std::numeric_limits<std::uint32_t>::max());
+}
+
+static void test_v2_adapter_defensively_preserves_missing_king_sentinel()
+{
+    // The authenticated V2 schema currently requires both kings. This direct
+    // adapter test protects the internal Position invariant if a future schema
+    // permits terminal records; it does not weaken the current reader.
+    Stockfish::Data::AtomicBinV2DecodedRecord decoded{};
+    auto& fields = decoded.fields;
+    fields.position.board.fill(Stockfish::Data::ATOMIC_BIN_V2_EMPTY);
+    fields.position.board[static_cast<std::size_t>(Stockfish::SQ_E8)] =
+        Stockfish::Data::ATOMIC_BIN_V2_BLACK_KING;
+    fields.position.board[static_cast<std::size_t>(Stockfish::SQ_A2)] =
+        Stockfish::Data::ATOMIC_BIN_V2_WHITE_PAWN;
+    fields.position.sideToMove = Stockfish::Data::ATOMIC_BIN_V2_WHITE_TO_MOVE;
+    fields.position.enPassantSquare = Stockfish::Data::AtomicBinV2NoSquare;
+    fields.position.castlingRookOrigins.fill(Stockfish::Data::AtomicBinV2NoSquare);
+    fields.position.fullmove = 1;
+    fields.move.from = static_cast<Stockfish::u8>(Stockfish::SQ_A2);
+    fields.move.to = static_cast<Stockfish::u8>(Stockfish::SQ_A3);
+    fields.move.type = Stockfish::Data::ATOMIC_BIN_V2_NORMAL;
+    fields.move.promotion = Stockfish::Data::ATOMIC_BIN_V2_NO_PROMOTION;
+
+    const auto entry = training_data::atomic_bin_v2::to_training_data_entry(decoded);
+    assert(entry.pos.kingSquare(Color::White) == chess::Square::NB);
+    assert(entry.pos.kingSquare(Color::Black) == sq(4, 7));
 }
 
 static void test_atomic_bin_v2_atomic960_and_stm_semantics()
@@ -769,6 +797,39 @@ static void test_atomic_bin_v2_corruption_and_schema_fail_closed()
         assert(std::string(get_sparse_batch_stream_creation_error()).find("SHA-256")
             != std::string::npos);
 
+    auto missing_king = create_v2_dataset(temporary.path, "missing-king", sample);
+    {
+        std::fstream shard(
+            missing_king.shard,
+            std::ios::in | std::ios::out | std::ios::binary);
+        assert(shard);
+        shard.seekg(static_cast<std::streamoff>(AtomicData::AtomicBinV2HeaderSize));
+        char first_board_byte = 0;
+        shard.read(&first_board_byte, 1);
+        assert(shard);
+        first_board_byte = static_cast<char>(
+            static_cast<unsigned char>(first_board_byte) & 0xF0U);
+        shard.seekp(static_cast<std::streamoff>(AtomicData::AtomicBinV2HeaderSize));
+        shard.write(&first_board_byte, 1);
+        assert(shard);
+    }
+    std::string missing_king_sha256;
+    Stockfish::u64 missing_king_size = 0;
+    assert(AtomicData::sha256_file(
+        missing_king.shard,
+        missing_king_sha256,
+        missing_king_size));
+    missing_king.metadata.shards.front().sha256 = std::move(missing_king_sha256);
+    assert(write_v2_manifest(missing_king.metadata));
+    const auto missing_king_manifest = utf8_path(missing_king.manifest);
+    stream = create_sparse_batch_stream_with_seed(
+        "HalfKAv2", 1, missing_king_manifest.c_str(), 1, false, false, 0, 0);
+    assert(stream != nullptr);
+    assert(fetch_next_sparse_batch(stream) == nullptr);
+    assert(std::string(get_sparse_batch_stream_error(stream)).find("king")
+        != std::string::npos);
+    destroy_sparse_batch_stream(stream);
+
     auto schema = create_v2_dataset(temporary.path, "schema", sample);
     std::ifstream input(schema.manifest, std::ios::binary);
     std::string json((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
@@ -897,6 +958,7 @@ int main()
     test_atomic_training_data_schema_handshake();
     test_atomic_bin_v2_manifest_only_roundtrip();
     test_widened_internal_position_boundaries();
+    test_v2_adapter_defensively_preserves_missing_king_sentinel();
     test_atomic_bin_v2_atomic960_and_stm_semantics();
     test_atomic_bin_v2_multishard_eof_partial_and_determinism();
     test_atomic_bin_v2_halfkav2_sparse_parity_with_legacy72();

--- a/tests/test_native_loader_integration.py
+++ b/tests/test_native_loader_integration.py
@@ -27,6 +27,36 @@ def test_atomic_training_data_schema_handshake():
     assert first['formats'] is not second['formats']
 
 
+def test_plural_atomic_training_data_schema_handshake_adds_manifest_v2():
+    expected = {
+        'capability_version': 2,
+        'formats': {
+            'legacy-atomic-v1': {
+                'schema_sha256': 'acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1',
+                'read': True,
+                'write': False,
+                'header_size': 0,
+                'record_size': 72,
+            },
+            'atomic-bin-v2': {
+                'read': True,
+                'write': False,
+                'entrypoint': 'manifest',
+                'header_size': 96,
+                'record_size': 64,
+                'schema_sha256': '0352b036f2a140c609e3eb9c9d635dc553e8d77253d8faa92437390f5cf93cb6',
+                'manifest_schema_sha256': '83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42',
+            },
+        },
+    }
+    assert nnue_dataset.atomic_training_data_schemas() == expected
+
+
+def test_plural_atomic_training_data_schema_requires_native_symbol():
+    with pytest.raises(RuntimeError, match='plural Atomic schema handshake'):
+        nnue_dataset._bind_atomic_training_data_schemas(object())
+
+
 @pytest.mark.parametrize(
     ('payload', 'message'),
     [
@@ -183,6 +213,45 @@ def test_native_batch_is_destroyed_when_tensor_conversion_fails(monkeypatch):
     finally:
         provider.__del__()
     assert destroyed == [pointer]
+
+
+def test_raw_atomic_bin_v2_creation_error_is_exposed():
+    with pytest.raises(RuntimeError, match='raw shards are not dataset entrypoints'):
+        nnue_dataset.SparseBatchProvider(
+            'HalfKAv2',
+            'raw.atbin',
+            1,
+            cyclic=False,
+            num_workers=1,
+            filtered=False,
+            random_fen_skipping=0,
+            device='cpu',
+            seed=0,
+        )
+
+
+def test_python_provider_reads_manifest_v2_from_unicode_path(atomic_v2_manifest):
+    provider = nnue_dataset.SparseBatchProvider(
+        'HalfKAv2',
+        str(atomic_v2_manifest),
+        2,
+        cyclic=False,
+        num_workers=2,
+        filtered=True,
+        random_fen_skipping=0,
+        device='cpu',
+        seed=0,
+    )
+    try:
+        batch = next(provider)
+        assert batch[0].shape == (1, 1)
+        assert batch[0].item() == 1.0
+        assert batch[6].item() == 0.0
+        assert batch[7].item() == -123.0
+        with pytest.raises(StopIteration):
+            next(provider)
+    finally:
+        provider.__del__()
 
 
 def test_full_size_corrupt_record_propagates_native_error(atomic_legacy_32, tmp_path):

--- a/tests/test_nnue_dataset_seed.py
+++ b/tests/test_nnue_dataset_seed.py
@@ -9,6 +9,9 @@ def test_seeded_native_loader_binding_is_available():
     assert hasattr(nnue_dataset.dll, "create_sparse_batch_stream")
     assert hasattr(nnue_dataset.dll, "create_sparse_batch_stream_with_seed")
     assert hasattr(nnue_dataset.dll, "get_sparse_batch_stream_error")
+    assert hasattr(nnue_dataset.dll, "get_sparse_batch_stream_creation_error")
+    assert hasattr(nnue_dataset.dll, "get_atomic_training_data_schemas_json")
+    assert hasattr(nnue_dataset.dll, "validate_training_validation_data_paths")
     assert len(nnue_dataset.create_sparse_batch_stream.argtypes) == 7
     assert nnue_dataset.create_sparse_batch_stream_with_seed.argtypes[-1] is ctypes.c_uint64
 

--- a/tests/test_train_reliability.py
+++ b/tests/test_train_reliability.py
@@ -69,6 +69,28 @@ def test_same_training_and_validation_file_is_rejected(tmp_path):
     train.validate_data_paths(str(data), str(data), allow_train_as_validation=True)
 
 
+def test_distinct_paths_delegate_native_v2_overlap_check(tmp_path, monkeypatch):
+    training = tmp_path / 'train.atbin.manifest.json'
+    validation = tmp_path / 'validation.atbin.manifest.json'
+    training.write_text('{}')
+    validation.write_text('{}')
+    calls = []
+    monkeypatch.setattr(
+        train.nnue_dataset,
+        'validate_training_validation_data_paths',
+        lambda left, right: calls.append((left, right)))
+
+    train.validate_data_paths(str(training), str(validation))
+    assert calls == [(str(training), str(validation))]
+
+    calls.clear()
+    train.validate_data_paths(
+        str(training),
+        str(validation),
+        allow_train_as_validation=True)
+    assert calls == []
+
+
 def test_relative_absolute_and_hardlink_aliases_are_rejected(tmp_path, monkeypatch):
     data = tmp_path / 'data.bin'
     alias = tmp_path / 'alias.bin'

--- a/train.py
+++ b/train.py
@@ -59,7 +59,7 @@ def require_single_device_trainer(trainer):
   world_size = int(trainer.world_size)
   if world_size != 1:
     raise ValueError(
-      'Legacy Atomic V1 training supports exactly one Lightning process/device; '
+      'Atomic native-stream training supports exactly one Lightning process/device; '
       'multi-device and multi-node strategies would duplicate the stateful native stream.'
     )
 
@@ -80,6 +80,9 @@ def validate_data_paths(train_filename, val_filename, allow_train_as_validation=
       'Training and validation must be separate files. '
       'Use --allow-train-as-validation only for an explicit smoke/debug run.'
     )
+
+  if not allow_train_as_validation:
+    nnue_dataset.validate_training_validation_data_paths(train_filename, val_filename)
 
 def make_data_loaders(train_filename, val_filename, feature_set, num_workers, batch_size, filtered, random_fen_skipping, main_device, epoch_size, val_size, seed):
   features_name = feature_set.name
@@ -121,8 +124,8 @@ def load_or_create_model(feature_set, lambda_, seed, resume_from_model=None):
 
 def main():
   parser = argparse.ArgumentParser(description="Trains the network.")
-  parser.add_argument("train", help="Training data (.bin)")
-  parser.add_argument("val", help="Validation data (.bin)")
+  parser.add_argument("train", help="Training data (.bin or .atbin.manifest.json)")
+  parser.add_argument("val", help="Validation data (.bin or .atbin.manifest.json)")
   parser = pl.Trainer.add_argparse_args(parser)
   parser.add_argument("--lambda", default=1.0, type=lambda_argument, dest='lambda_', help="lambda=1.0 = train on evaluations, lambda=0.0 = train on game results, interpolates between (default=1.0).")
   parser.add_argument("--num-workers", default=1, type=positive_int32, dest='num_workers', help="Number of native worker threads to use for data loading.")
@@ -172,7 +175,19 @@ def main():
     batch_size = default_batch_size(main_device)
   print('Using batch size {}'.format(batch_size))
 
-  print('Smart fen skipping: {}'.format(not args.no_smart_fen_skipping))
+  smart_filter_requested = not args.no_smart_fen_skipping
+  v2_inputs = [
+    label for label, path in (('train', args.train), ('validation', args.val))
+    if os.fspath(path).lower().endswith('.atbin.manifest.json')
+  ]
+  if v2_inputs:
+    print(
+      'Smart fen skipping: {} for Legacy input; bypassed for Atomic BIN V2 {} '
+      '(authenticated generator policy)'.format(
+        smart_filter_requested,
+        ' and '.join(v2_inputs)))
+  else:
+    print('Smart fen skipping: {}'.format(smart_filter_requested))
   print('Random fen skipping: {}'.format(args.random_fen_skipping))
 
   print('Using c++ data loader')

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -12,10 +12,12 @@
 #include <exception>
 #include <iterator>
 #include <future>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <random>
 #include <stdexcept>
@@ -23,10 +25,13 @@
 
 #include "lib/nnue_training_data_formats.h"
 #include "lib/nnue_training_data_stream.h"
+#include "lib/dataset_file_identity.h"
 
 #if defined(_WIN32)
 #define EXPORT __declspec(dllexport)
+#ifndef CDECL
 #define CDECL __cdecl
+#endif
 #else
 #define EXPORT
 #define CDECL
@@ -45,10 +50,120 @@ static constexpr int MAX_HAND_PIECES = POCKETS ? 2 * static_cast<int>(File::FILE
 
 namespace {
 
+thread_local std::array<char, 1024> g_creation_error{};
+thread_local std::array<char, 1024> g_dataset_pair_error{};
+
+using training_data::platform::DatasetFileIdentity;
+using training_data::platform::dataset_file_identity;
+
+void set_creation_error(const char* message) noexcept
+{
+    std::snprintf(
+        g_creation_error.data(),
+        g_creation_error.size(),
+        "%s",
+        message == nullptr ? "unknown native loader creation error" : message);
+}
+
+const char* validate_dataset_pair(const char* training_path, const char* validation_path) noexcept
+{
+    g_dataset_pair_error[0] = '\0';
+    const auto fail = [](const std::string& message) -> const char* {
+        std::snprintf(
+            g_dataset_pair_error.data(),
+            g_dataset_pair_error.size(),
+            "%s",
+            message.c_str());
+        return g_dataset_pair_error.data();
+    };
+
+    if (training_path == nullptr || validation_path == nullptr)
+        return fail("training and validation paths must not be null");
+
+    const std::string training(training_path);
+    const std::string validation(validation_path);
+    if (training_data::has_extension(training, "atbin")
+        || training_data::has_extension(validation, "atbin"))
+        return fail(
+            "Atomic BIN V2 raw shards are not dataset entrypoints; use .atbin.manifest.json sidecars");
+
+    if (!training_data::is_atomic_bin_v2_manifest(training)
+        || !training_data::is_atomic_bin_v2_manifest(validation))
+        return nullptr;
+
+    try
+    {
+        std::unique_ptr<Stockfish::Data::AtomicBinV2DatasetReader> training_reader;
+        std::unique_ptr<Stockfish::Data::AtomicBinV2DatasetReader> validation_reader;
+        auto opened = Stockfish::Data::AtomicBinV2DatasetReader::open(
+            std::filesystem::u8path(training), training_reader);
+        if (!opened)
+            return fail("invalid training manifest: " + opened.message);
+        opened = Stockfish::Data::AtomicBinV2DatasetReader::open(
+            std::filesystem::u8path(validation), validation_reader);
+        if (!opened)
+            return fail("invalid validation manifest: " + opened.message);
+
+        const auto& training_shards = training_reader->manifest().shards;
+        const auto& validation_shards = validation_reader->manifest().shards;
+        std::map<std::string, std::size_t> hash_indices;
+        std::map<std::filesystem::path, std::size_t> path_indices;
+        std::map<DatasetFileIdentity, std::size_t> identity_indices;
+        for (std::size_t index = 0; index < training_shards.size(); ++index)
+        {
+            const auto& shard = training_shards[index];
+            hash_indices.emplace(shard.sha256, index);
+            path_indices.emplace(shard.path.lexically_normal(), index);
+            if (const auto identity = dataset_file_identity(shard.path))
+                identity_indices.emplace(*identity, index);
+        }
+        for (std::size_t validation_index = 0;
+             validation_index < validation_shards.size();
+             ++validation_index)
+        {
+            const auto& shard = validation_shards[validation_index];
+            std::optional<std::size_t> training_index;
+            if (const auto found = hash_indices.find(shard.sha256); found != hash_indices.end())
+                training_index = found->second;
+            else if (const auto found = path_indices.find(shard.path.lexically_normal());
+                     found != path_indices.end())
+                training_index = found->second;
+            else if (const auto identity = dataset_file_identity(shard.path))
+                if (const auto found = identity_indices.find(*identity);
+                    found != identity_indices.end())
+                    training_index = found->second;
+
+            if (training_index)
+                return fail(
+                    "training and validation Atomic BIN V2 manifests overlap at train shard "
+                    + std::to_string(*training_index) + " and validation shard "
+                    + std::to_string(validation_index));
+        }
+        return nullptr;
+    }
+    catch (const std::exception& error)
+    {
+        return fail(std::string("cannot validate training/validation manifests: ") + error.what());
+    }
+    catch (...)
+    {
+        return fail("cannot validate training/validation manifests: unknown native error");
+    }
+}
+
 constexpr char ATOMIC_TRAINING_DATA_SCHEMA_JSON[] =
     "{\"schema_sha256\":\"acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1\","
     "\"formats\":{\"legacy-atomic-v1\":{\"read\":true,\"write\":false,"
     "\"record_size\":72}}}";
+
+constexpr char ATOMIC_TRAINING_DATA_SCHEMAS_JSON[] =
+    "{\"capability_version\":2,\"formats\":{\"legacy-atomic-v1\":{"
+    "\"schema_sha256\":\"acca0f551f1c012c31a6c727dedccaebb7b5ebbc46810edb87e31bb208d5abe1\","
+    "\"read\":true,\"write\":false,\"header_size\":0,\"record_size\":72},"
+    "\"atomic-bin-v2\":{\"read\":true,\"write\":false,"
+    "\"entrypoint\":\"manifest\",\"header_size\":96,\"record_size\":64,"
+    "\"schema_sha256\":\"0352b036f2a140c609e3eb9c9d635dc553e8d77253d8faa92437390f5cf93cb6\","
+    "\"manifest_schema_sha256\":\"83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42\"}}}";
 
 static_assert(
     sizeof(bin::nodchip::PackedSfenValue) == 72,
@@ -419,7 +534,7 @@ private:
     {
         is_white[i] = static_cast<float>(e.pos.sideToMove() == Color::White);
         outcome[i] = (e.result + 1.0f) / 2.0f;
-        score[i] = e.score;
+        score[i] = static_cast<float>(e.score);
         psqt_indices[i] = (e.pos.pieceCount() - 1) * 8 / MAX_PIECES;
         layer_stack_indices[i] = psqt_indices[i];
         fill_features(FeatureSet<Ts...>{}, i, e);
@@ -452,14 +567,18 @@ struct Stream : AnyStream
         m_stream(training_data::open_sfen_input_file_parallel(concurrency, filename, cyclic, skipPredicate))
     {
         if (!m_stream)
-            throw std::invalid_argument("Unsupported training-data file (expected a .bin file)");
+            throw std::invalid_argument(
+                "Unsupported training-data file (expected .bin or .atbin.manifest.json)");
 
-        std::ifstream input(filename, std::ios::binary | std::ios::ate);
-        if (!input)
-            throw std::invalid_argument("Could not open the training-data file");
-        const auto size = static_cast<std::streamoff>(input.tellg());
-        if (size <= 0 || size % static_cast<std::streamoff>(sizeof(bin::nodchip::PackedSfenValue)) != 0)
-            throw std::invalid_argument("Legacy training-data size must be a positive multiple of 72 bytes");
+        if (training_data::has_extension(filename, training_data::BinSfenInputStream::extension))
+        {
+            std::ifstream input(filename, std::ios::binary | std::ios::ate);
+            if (!input)
+                throw std::invalid_argument("Could not open the training-data file");
+            const auto size = static_cast<std::streamoff>(input.tellg());
+            if (size <= 0 || size % static_cast<std::streamoff>(sizeof(bin::nodchip::PackedSfenValue)) != 0)
+                throw std::invalid_argument("Legacy training-data size must be a positive multiple of 72 bytes");
+        }
     }
 
     virtual StorageT* next() = 0;
@@ -838,22 +957,48 @@ extern "C" {
         return ATOMIC_TRAINING_DATA_SCHEMA_JSON;
     }
 
+    EXPORT const char* CDECL get_atomic_training_data_schemas_json()
+    {
+        return ATOMIC_TRAINING_DATA_SCHEMAS_JSON;
+    }
+
+    EXPORT const char* CDECL get_sparse_batch_stream_creation_error()
+    {
+        return g_creation_error.data();
+    }
+
+    EXPORT const char* CDECL validate_training_validation_data_paths(
+        const char* training_path,
+        const char* validation_path)
+    {
+        return validate_dataset_pair(training_path, validation_path);
+    }
+
     EXPORT Stream<SparseBatch>* CDECL create_sparse_batch_stream_with_seed(const char* feature_set_c, int concurrency, const char* filename, int batch_size, bool cyclic, bool filtered, int random_fen_skipping, std::uint64_t seed)
     {
+        g_creation_error[0] = '\0';
         if (feature_set_c == nullptr || filename == nullptr)
         {
-            fprintf(stderr, "feature_set and filename must not be null\n");
+            set_creation_error("feature_set and filename must not be null");
+            fprintf(stderr, "%s\n", g_creation_error.data());
             return nullptr;
         }
         if (concurrency < 1 || batch_size < 1 || random_fen_skipping < 0)
         {
-            fprintf(stderr, "Invalid loader configuration: concurrency and batch_size must be positive, random_fen_skipping must be non-negative\n");
+            set_creation_error("Invalid loader configuration: concurrency and batch_size must be positive, random_fen_skipping must be non-negative");
+            fprintf(stderr, "%s\n", g_creation_error.data());
             return nullptr;
         }
 
         try
         {
-            auto skipPredicate = make_skip_predicate(filtered, random_fen_skipping, seed);
+            const bool atomic_bin_v2 = training_data::is_atomic_bin_v2_manifest(filename);
+            if (atomic_bin_v2 && filtered)
+                fprintf(stderr, "Atomic BIN V2 ignores trainer-side smart filtering; using the authenticated generator manifest policy\n");
+            auto skipPredicate = make_skip_predicate(
+                atomic_bin_v2 ? false : filtered,
+                random_fen_skipping,
+                seed);
             std::string_view feature_set(feature_set_c);
             if (feature_set == "HalfKP")
                 return new FeaturedBatchStream<FeatureSet<HalfKP>, SparseBatch>(concurrency, filename, batch_size, cyclic, skipPredicate);
@@ -868,16 +1013,20 @@ extern "C" {
             if (feature_set == "HalfKAv2^")
                 return new FeaturedBatchStream<FeatureSet<HalfKAv2Factorized>, SparseBatch>(concurrency, filename, batch_size, cyclic, skipPredicate);
 
-            fprintf(stderr, "Unknown feature_set %s\n", feature_set_c);
+            const std::string error = "Unknown feature_set " + std::string(feature_set_c);
+            set_creation_error(error.c_str());
+            fprintf(stderr, "%s\n", g_creation_error.data());
             return nullptr;
         }
         catch (const std::exception& error)
         {
+            set_creation_error(error.what());
             fprintf(stderr, "Failed to create sparse batch stream: %s\n", error.what());
             return nullptr;
         }
         catch (...)
         {
+            set_creation_error("unknown native loader error");
             fprintf(stderr, "Failed to create sparse batch stream: unknown error\n");
             return nullptr;
         }
@@ -887,7 +1036,28 @@ extern "C" {
     // the seeded entry point above; legacy callers retain their old behavior.
     EXPORT Stream<SparseBatch>* CDECL create_sparse_batch_stream(const char* feature_set_c, int concurrency, const char* filename, int batch_size, bool cyclic, bool filtered, int random_fen_skipping)
     {
-        return create_sparse_batch_stream_with_seed(feature_set_c, concurrency, filename, batch_size, cyclic, filtered, random_fen_skipping, std::random_device{}());
+        try
+        {
+            return create_sparse_batch_stream_with_seed(
+                feature_set_c,
+                concurrency,
+                filename,
+                batch_size,
+                cyclic,
+                filtered,
+                random_fen_skipping,
+                std::random_device{}());
+        }
+        catch (const std::exception& error)
+        {
+            set_creation_error(error.what());
+            return nullptr;
+        }
+        catch (...)
+        {
+            set_creation_error("unknown random-seed initialization error");
+            return nullptr;
+        }
     }
 
     EXPORT void CDECL destroy_sparse_batch_stream(Stream<SparseBatch>* stream)


### PR DESCRIPTION
## Summary

- pin Atomic-Stockfish at `1e64c6f16e8c327be6ee5e3de57ed54d1079f060` and authenticate the gitlink, upstream URL, clean checkout, `origin/main` ancestry, and both V2 schema hashes
- accept Atomic BIN V2 only through authenticated `*.atbin.manifest.json` entrypoints while preserving the byte-exact Legacy Atomic V1 handshake and 72-byte reader
- preserve signed 32-bit scores, unsigned 32-bit plies, rule50/fullmove widths, STM semantics, Atomic960 rook origins, multishard ordering, Unicode paths, and final partial batches
- bypass the historical trainer smart filter for V2 and report the generator policy authenticated by the manifest
- reject train/validation overlap by shard digest, normalized path, or physical file identity
- add the GPL-3.0-or-later license and corresponding-source notice required by the statically linked Atomic-Stockfish reader

## Validation

- MSVC Release configure/build/install: PASS
- `ctest --test-dir build-v2 -C Release --output-on-failure`: 1/1 PASS
- `python -m pytest -q`: 63/63 PASS, 0 failures/errors/skips
- direct Legacy72 vs V2 full sparse HalfKAv2 parity for both perspectives, including KING-to-legacy-COMMONER feature-plane compatibility
- `git diff --check`: clean

Target is the dedicated `atomic` branch; this PR does not target upstream `main`.