### PR TITLE
H7: repin trainer to lossless decode engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(ATOMIC_STOCKFISH_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/external/Atomic-Stockfish")
-set(ATOMIC_STOCKFISH_PIN "1e64c6f16e8c327be6ee5e3de57ed54d1079f060")
+set(ATOMIC_STOCKFISH_PIN "76764c3c01ce5965a793a65e4580dd5c95cd2916")
 set(ATOMIC_BIN_V2_DATA_SCHEMA_SHA256
   "0352b036f2a140c609e3eb9c9d635dc553e8d77253d8faa92437390f5cf93cb6")
 set(ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256
   "83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42")
+set(ATOMIC_DATA_TOOLS_DECODE_SCHEMA_SHA256
+  "5e3f8d7c6db6ee955b71747ee063859e15609adb557a3754228a606f3df2caad")
 if(NOT EXISTS "${ATOMIC_STOCKFISH_ROOT}/src/data/atomic_bin_v2_reader.cpp")
   message(FATAL_ERROR
     "Atomic-Stockfish submodule is missing; run git submodule update --init --recursive")
@@ -85,11 +87,17 @@ file(SHA256
 file(SHA256
   "${ATOMIC_STOCKFISH_ROOT}/schemas/atomic-bin-v2-manifest.json"
   ATOMIC_BIN_V2_MANIFEST_SCHEMA_ACTUAL)
+file(SHA256
+  "${ATOMIC_STOCKFISH_ROOT}/schemas/atomic-data-tools-decode-v1.json"
+  ATOMIC_DATA_TOOLS_DECODE_SCHEMA_ACTUAL)
 if(NOT ATOMIC_BIN_V2_DATA_SCHEMA_ACTUAL STREQUAL ATOMIC_BIN_V2_DATA_SCHEMA_SHA256)
   message(FATAL_ERROR "Pinned Atomic BIN V2 data schema hash differs")
 endif()
 if(NOT ATOMIC_BIN_V2_MANIFEST_SCHEMA_ACTUAL STREQUAL ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256)
   message(FATAL_ERROR "Pinned Atomic BIN V2 manifest schema hash differs")
+endif()
+if(NOT ATOMIC_DATA_TOOLS_DECODE_SCHEMA_ACTUAL STREQUAL ATOMIC_DATA_TOOLS_DECODE_SCHEMA_SHA256)
+  message(FATAL_ERROR "Pinned Atomic data-tools decode schema hash differs")
 endif()
 
 add_library(atomic_bin_v2_reader_core STATIC

--- a/docs/atomic-bin-v2.md
+++ b/docs/atomic-bin-v2.md
@@ -7,9 +7,18 @@ record decoding, Atomic legality and byte-exact canonical validation to the
 pinned Atomic-Stockfish reader.
 
 The engine submodule is fixed to
-`1e64c6f16e8c327be6ee5e3de57ed54d1079f060`. Configuration fails if the
+`76764c3c01ce5965a793a65e4580dd5c95cd2916`. Configuration fails if the
 gitlink, checkout, origin URL, schema hashes or `origin/main` ancestry differ,
-or if the submodule is dirty.
+or if the submodule is dirty. In addition to the data and manifest schemas,
+the cross-repository handoff authenticates the public lossless decoder schema
+as SHA-256
+`5e3f8d7c6db6ee955b71747ee063859e15609adb557a3754228a606f3df2caad`.
+
+The trainer continues to link the manifest reader directly and does not invoke
+the data-tools CLI. Its plural training-data capability handshake and reader
+semantics are intentionally unchanged by this repin; the exact engine pin and
+decode-schema hash merely authenticate the decoder contract used elsewhere in
+the end-to-end pipeline.
 
 Because the native loader statically links this pinned Atomic-Stockfish code,
 the resulting component is distributed under `GPL-3.0-or-later`. The complete


### PR DESCRIPTION
## What changed

- repin the Atomic-Stockfish submodule and CMake supply-chain guard to engine merge `76764c3c01ce5965a793a65e4580dd5c95cd2916`
- authenticate the frozen lossless decoder schema (`5e3f8d7c6db6ee955b71747ee063859e15609adb557a3754228a606f3df2caad`) during CMake configuration
- document the exact H7.5 cross-repository handoff

## Why

The trainer must consume the exact engine revision used by the completed Atomic BIN V2 decode contract. The old H7.4 pin predated the public lossless decoder schema.

## Impact

The native manifest reader, training behavior, and trainer capability handshake are unchanged. The trainer still links the reader directly and does not invoke the data-tools CLI. Configuration now fails closed if the H7.5 gitlink, checkout, origin, ancestry, cleanliness, or decode-schema bytes differ.

Historical fixture manifests intentionally retain the older engine commit to preserve backwards-compatibility coverage.

## Validation

- CMake configure, MSVC 19.44, Release, `BUILD_TESTING=ON`
- native loader build and install
- `ctest -C Release --output-on-failure`: 1/1 passed
- `python -B -m pytest -q -p no:cacheprovider`: 63 passed (expected CUDA skips/warnings on CPU host)
- exact gitlink/submodule SHA and decode-schema SHA-256 assertions
- `git diff --check`