### PR TITLE
H9.2: add isolated AtomicNNUEV2 trainer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+atomic_v2/schema/*.json text eol=lf

--- a/.github/workflows/trainer-tests.yml
+++ b/.github/workflows/trainer-tests.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: recursive
 
       - name: Fetch audited Atomic-Stockfish main ref
-        run: git -C external/Atomic-Stockfish fetch --no-tags origin main:refs/remotes/origin/main
+        run: git -C external/Atomic-Stockfish fetch --no-tags --depth=2147483647 origin +refs/heads/main:refs/remotes/origin/main
 
       - uses: actions/setup-python@v5
         with:
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
 
       - name: Fetch audited Atomic-Stockfish main ref
-        run: git -C external/Atomic-Stockfish fetch --no-tags origin main:refs/remotes/origin/main
+        run: git -C external/Atomic-Stockfish fetch --no-tags --depth=2147483647 origin +refs/heads/main:refs/remotes/origin/main
 
       - uses: actions/setup-python@v5
         with:

--- a/atomic_v2/__init__.py
+++ b/atomic_v2/__init__.py
@@ -1,0 +1,10 @@
+"""Isolated AtomicNNUEV2 trainer and wire-format support.
+
+The historical trainer remains at the repository root.  This package is the
+additive SFNNv15 path and deliberately does not auto-convert legacy V1 nets.
+"""
+
+from .contract import BACKEND_NAME, FILE_VERSION, NETWORK_HASH
+from .model import AtomicNNUEV2
+
+__all__ = ["AtomicNNUEV2", "BACKEND_NAME", "FILE_VERSION", "NETWORK_HASH"]

--- a/atomic_v2/checkpoint.py
+++ b/atomic_v2/checkpoint.py
@@ -1,0 +1,94 @@
+"""Backend-tagged V2 checkpoints; never accepts legacy model objects."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from .contract import BACKEND_KEY, FILE_VERSION, NETWORK_HASH
+from .model import AtomicNNUEV2
+
+
+class CheckpointError(ValueError):
+    pass
+
+
+def validate_checkpoint_document(document: Any) -> dict[str, Any]:
+    if not isinstance(document, dict):
+        raise CheckpointError("Atomic V2 checkpoint must be a dictionary")
+    expected = {
+        "backend": BACKEND_KEY,
+        "file_version": FILE_VERSION,
+        "network_hash": NETWORK_HASH,
+    }
+    for key, expected_value in expected.items():
+        if document.get(key) != expected_value:
+            raise CheckpointError(
+                f"checkpoint {key} is {document.get(key)!r}, expected {expected_value!r}"
+            )
+    if not isinstance(document.get("model_state"), dict):
+        raise CheckpointError("checkpoint is missing model_state")
+    step = document.get("step")
+    if isinstance(step, bool) or not isinstance(step, int) or step < 0:
+        raise CheckpointError("checkpoint step must be a non-negative integer")
+    return document
+
+
+def checkpoint_document(
+    model: AtomicNNUEV2,
+    *,
+    step: int,
+    optimizer: torch.optim.Optimizer | None = None,
+) -> dict[str, Any]:
+    if not isinstance(model, AtomicNNUEV2):
+        raise TypeError("Atomic V2 checkpoints accept only AtomicNNUEV2 models")
+    document: dict[str, Any] = {
+        "backend": BACKEND_KEY,
+        "file_version": FILE_VERSION,
+        "network_hash": NETWORK_HASH,
+        "step": step,
+        "model_state": model.state_dict(),
+    }
+    if optimizer is not None:
+        document["optimizer_state"] = optimizer.state_dict()
+    return validate_checkpoint_document(document)
+
+
+def save_checkpoint(
+    path: str | Path,
+    model: AtomicNNUEV2,
+    *,
+    step: int,
+    optimizer: torch.optim.Optimizer | None = None,
+) -> None:
+    target = Path(path)
+    temporary = target.with_name(target.name + ".tmp")
+    if target.exists() or temporary.exists():
+        raise FileExistsError(f"refusing to overwrite checkpoint: {target}")
+    try:
+        torch.save(checkpoint_document(model, step=step, optimizer=optimizer), temporary)
+        os.replace(temporary, target)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def load_checkpoint(
+    path: str | Path,
+    *,
+    load_optimizer: bool = False,
+) -> tuple[AtomicNNUEV2, int, dict[str, Any] | None]:
+    # `weights_only=True` limits deserialization to tensors and primitive
+    # containers; V1's pickled model object is therefore not an implicit path.
+    document = torch.load(path, map_location="cpu", weights_only=True)
+    validate_checkpoint_document(document)
+    model = AtomicNNUEV2(initialize=False)
+    try:
+        model.load_state_dict(document["model_state"], strict=True)
+    except RuntimeError as error:
+        raise CheckpointError("checkpoint model_state does not match AtomicNNUEV2") from error
+    optimizer_state = document.get("optimizer_state") if load_optimizer else None
+    return model, document["step"], optimizer_state

--- a/atomic_v2/contract.py
+++ b/atomic_v2/contract.py
@@ -1,0 +1,155 @@
+"""Authenticated AtomicNNUEV2 contract shared with Atomic-Stockfish."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.resources import files
+from typing import Any
+
+
+CONTRACT_SOURCE_COMMIT = "0818886d77328fe25850a3187e6460adaa980316"
+CONTRACT_SOURCE_BLOB = "8a8003cbf5f7b97b50470de898ae16074aad7bca"
+CONTRACT_SOURCE_SHA256 = "70ea8da4cdd2f209fafc25f9419d3b3f226711b00701bf2fc02587dba65b82d7"
+OFFICIAL_TRAINER_COMMIT = "b8512291deb4cd18afa67003bb6bc53dd522cbf0"
+
+BACKEND_KEY = "atomic-nnue-v2"
+BACKEND_NAME = "AtomicNNUEV2"
+FEATURE_NAME = "HalfKAv2Atomic"
+FILE_VERSION = 0xA70C0002
+FEATURE_HASH = 0x5F234CB8
+FEATURE_TRANSFORMER_HASH = 0x5F2344B8
+ARCHITECTURE_HASH = 0x63337116
+NETWORK_HASH = 0x3C1035AE
+FEATURE_DIMENSIONS = 45056
+ACCUMULATOR_DIMENSIONS = 1024
+TRANSFORMED_DIMENSIONS = 1024
+PSQT_BUCKETS = 8
+LAYER_STACKS = 8
+FC0_OUTPUTS = 32
+FC1_INPUTS = 64
+FC1_OUTPUTS = 32
+FC2_INPUTS = 128
+FC2_OUTPUTS = 1
+MAX_DESCRIPTION_BYTES = 1 << 20
+
+
+class ContractError(ValueError):
+    """The vendored or supplied V2 contract is not the pinned contract."""
+
+
+_EXPECTED_BACKEND: dict[str, Any] = {
+    "file_version": "0xA70C0002",
+    "feature_set": FEATURE_NAME,
+    "feature_dimensions": FEATURE_DIMENSIONS,
+    "accumulator_dimensions_per_perspective": ACCUMULATOR_DIMENSIONS,
+    "feature_transformer_output_dimensions": TRANSFORMED_DIMENSIONS,
+    "feature_transformer_hash_xor": 2048,
+    "feature_set_hash": "0x5F234CB8",
+    "feature_transformer_hash": "0x5F2344B8",
+    "architecture_hash": "0x63337116",
+    "network_hash": "0x3C1035AE",
+    "psqt_buckets": PSQT_BUCKETS,
+    "layer_stacks": LAYER_STACKS,
+    "pairwise_multiply": {
+        "input_dimensions_per_perspective": 1024,
+        "half_dimensions": 512,
+        "output_dimensions_per_perspective": 512,
+        "concatenated_output_dimensions": 1024,
+    },
+    "topology": {
+        "fc0": {"input_dimensions": 1024, "output_dimensions": 32},
+        "fc1": {"input_dimensions": 64, "output_dimensions": 32},
+        "fc2": {"input_dimensions": 128, "output_dimensions": 1},
+        "activation_paths": {
+            "after_fc0": ["squared-clipped-relu", "clipped-relu"],
+            "after_fc1": ["squared-clipped-relu", "clipped-relu"],
+        },
+        "fc0_skip_indices": [30, 31],
+        "fc0_skip_coefficients": [1, -1],
+        "output_scaling": {
+            "hidden_one": 128,
+            "weight_scale_bits": 6,
+            "output_scale": 16,
+            "network_unit_scale": 600,
+            "multiplier": 9600,
+            "denominator": 16384,
+        },
+    },
+}
+
+
+def contract_bytes() -> bytes:
+    return files("atomic_v2").joinpath("schema", "atomic-nnue-v2.json").read_bytes()
+
+
+def load_contract() -> dict[str, Any]:
+    raw = contract_bytes()
+    actual_sha = hashlib.sha256(raw).hexdigest()
+    if actual_sha != CONTRACT_SOURCE_SHA256:
+        raise ContractError(
+            f"contract SHA-256 mismatch: expected {CONTRACT_SOURCE_SHA256}, got {actual_sha}"
+        )
+    try:
+        document = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ContractError("contract is not valid UTF-8 JSON") from error
+    validate_contract(document)
+    return document
+
+
+def _first_difference(expected: Any, actual: Any, path: str) -> str | None:
+    if type(expected) is not type(actual):
+        return f"{path} has type {type(actual).__name__}, expected {type(expected).__name__}"
+    if isinstance(expected, dict):
+        if set(expected) != set(actual):
+            missing = sorted(set(expected) - set(actual))
+            extra = sorted(set(actual) - set(expected))
+            return f"{path} keys differ (missing={missing}, extra={extra})"
+        for key in expected:
+            difference = _first_difference(expected[key], actual[key], f"{path}.{key}")
+            if difference:
+                return difference
+        return None
+    if isinstance(expected, list):
+        if len(expected) != len(actual):
+            return f"{path} length is {len(actual)}, expected {len(expected)}"
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            difference = _first_difference(expected_item, actual_item, f"{path}[{index}]")
+            if difference:
+                return difference
+        return None
+    if expected != actual:
+        return f"{path} is {actual!r}, expected {expected!r}"
+    return None
+
+
+def validate_contract(document: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(document, dict):
+        raise ContractError("contract root must be an object")
+    expected_root = {
+        "schema_version": 1,
+        "schema_id": "atomic-nnue-dual-backend-v1",
+        "variant": "atomic",
+        "byte_order": "little-endian",
+    }
+    for key, expected in expected_root.items():
+        if document.get(key) != expected:
+            raise ContractError(f"{key} is {document.get(key)!r}, expected {expected!r}")
+    backends = document.get("backends")
+    if not isinstance(backends, dict) or BACKEND_KEY not in backends:
+        raise ContractError(f"missing backends.{BACKEND_KEY}")
+    backend = backends[BACKEND_KEY]
+    difference = _first_difference(_EXPECTED_BACKEND, backend, f"backends.{BACKEND_KEY}")
+    if difference:
+        raise ContractError(difference)
+
+    if FEATURE_TRANSFORMER_HASH != (FEATURE_HASH ^ (ACCUMULATOR_DIMENSIONS * 2)):
+        raise ContractError("feature-transformer hash derivation is inconsistent")
+    if NETWORK_HASH != (FEATURE_TRANSFORMER_HASH ^ ARCHITECTURE_HASH):
+        raise ContractError("network hash derivation is inconsistent")
+    return backend
+
+
+# Fail during import if even the bytes of the package and engine contract drift.
+_PINNED_CONTRACT = load_contract()

--- a/atomic_v2/dataset.py
+++ b/atomic_v2/dataset.py
@@ -1,0 +1,176 @@
+"""Strict adapter from the existing Atomic native loader to V2 batches."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+import torch
+
+
+ATOMIC_BIN_V2_SCHEMA_SHA256 = "0352b036f2a140c609e3eb9c9d635dc553e8d77253d8faa92437390f5cf93cb6"
+ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256 = (
+    "83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42"
+)
+EXPECTED_V2_CAPABILITY = {
+    "read": True,
+    "write": False,
+    "entrypoint": "manifest",
+    "header_size": 96,
+    "record_size": 64,
+    "schema_sha256": ATOMIC_BIN_V2_SCHEMA_SHA256,
+    "manifest_schema_sha256": ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256,
+}
+
+
+class DatasetContractError(ValueError):
+    pass
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    document: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in document:
+            raise DatasetContractError(f"duplicate manifest property: {key}")
+        document[key] = value
+    return document
+
+
+def validate_v2_manifest_entrypoint(manifest: str | Path) -> Path:
+    """Fail closed before handing a dataset path to the dual-format loader.
+
+    The native provider deliberately retains Legacy Atomic V1 support for the
+    historical trainer.  V2 must therefore authenticate its manifest boundary
+    explicitly instead of relying on format auto-detection in that provider.
+    Full schema, shard and record validation remains native and SHA-pinned.
+    """
+
+    path = Path(manifest)
+    if not path.name.endswith(".atbin.manifest.json"):
+        raise DatasetContractError(
+            "AtomicNNUEV2 requires an .atbin.manifest.json entrypoint"
+        )
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    try:
+        raw = path.read_bytes()
+        document = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except DatasetContractError:
+        raise
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DatasetContractError(f"invalid atomic-bin-v2 manifest: {error}") from error
+    if not isinstance(document, dict):
+        raise DatasetContractError("atomic-bin-v2 manifest root must be an object")
+    if type(document.get("manifest_version")) is not int or document["manifest_version"] != 1:
+        raise DatasetContractError("atomic-bin-v2 manifest_version must be 1")
+    expected_fields = {
+        "format": "atomic-bin-v2",
+        "data_schema_sha256": ATOMIC_BIN_V2_SCHEMA_SHA256,
+        "manifest_schema_sha256": ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256,
+    }
+    for field, expected in expected_fields.items():
+        if document.get(field) != expected:
+            raise DatasetContractError(
+                f"atomic-bin-v2 manifest {field} mismatch: {document.get(field)!r}"
+            )
+    return path
+
+
+def validate_loader_capabilities(document: dict[str, Any]) -> None:
+    if not isinstance(document, dict):
+        raise DatasetContractError("native loader capabilities must be an object")
+    if document.get("capability_version") != 2:
+        raise DatasetContractError("native loader capability_version must be 2")
+    formats = document.get("formats")
+    if not isinstance(formats, dict):
+        raise DatasetContractError("native loader capabilities are missing formats")
+    actual = formats.get("atomic-bin-v2")
+    if actual != EXPECTED_V2_CAPABILITY:
+        raise DatasetContractError(
+            f"native atomic-bin-v2 capability mismatch: {actual!r}"
+        )
+
+
+def validate_batch(batch: Sequence[torch.Tensor]) -> tuple[torch.Tensor, ...]:
+    if not isinstance(batch, (tuple, list)) or len(batch) != 10:
+        raise DatasetContractError("Atomic loader batch must contain exactly 10 tensors")
+    tensors = tuple(batch)
+    if not all(isinstance(value, torch.Tensor) for value in tensors):
+        raise DatasetContractError("Atomic loader batch entries must all be tensors")
+    (
+        us,
+        them,
+        white_indices,
+        white_values,
+        black_indices,
+        black_values,
+        outcome,
+        score,
+        psqt_indices,
+        layer_stack_indices,
+    ) = tensors
+    batch_size = us.shape[0]
+    if us.shape != (batch_size, 1) or them.shape != us.shape:
+        raise DatasetContractError("us/them must have shape [batch, 1]")
+    if white_indices.shape != black_indices.shape:
+        raise DatasetContractError("white/black feature index shapes differ")
+    if white_values.shape != white_indices.shape or black_values.shape != black_indices.shape:
+        raise DatasetContractError("feature value shapes do not match feature indices")
+    if white_indices.shape[0] != batch_size:
+        raise DatasetContractError("feature batch size does not match us/them")
+    if outcome.shape != (batch_size, 1) or score.shape != (batch_size, 1):
+        raise DatasetContractError("outcome/score must have shape [batch, 1]")
+    if psqt_indices.shape != (batch_size,) or layer_stack_indices.shape != (batch_size,):
+        raise DatasetContractError("bucket tensors must have shape [batch]")
+    if white_indices.dtype != torch.int32 or black_indices.dtype != torch.int32:
+        raise DatasetContractError("feature indices must use torch.int32")
+    if white_values.dtype != torch.float32 or black_values.dtype != torch.float32:
+        raise DatasetContractError("feature values must use torch.float32")
+    if any(value.dtype != torch.float32 for value in (us, them, outcome, score)):
+        raise DatasetContractError("us/them/outcome/score must use torch.float32")
+    if psqt_indices.dtype != torch.long or layer_stack_indices.dtype != torch.long:
+        raise DatasetContractError("bucket indices must use torch.long")
+    return tensors
+
+
+def create_provider(
+    manifest: str | Path,
+    *,
+    batch_size: int,
+    num_workers: int = 1,
+    device: str = "cpu",
+    seed: int = 0,
+    cyclic: bool = True,
+):
+    manifest_path = validate_v2_manifest_entrypoint(manifest)
+    # Import lazily so contract/model/serializer unit tests do not require a
+    # platform-specific native loader binary.
+    import nnue_dataset
+
+    validate_loader_capabilities(nnue_dataset.atomic_training_data_schemas())
+    return nnue_dataset.SparseBatchProvider(
+        "HalfKAv2",
+        str(manifest_path),
+        batch_size,
+        cyclic=cyclic,
+        num_workers=num_workers,
+        filtered=False,
+        random_fen_skipping=0,
+        device=device,
+        seed=seed,
+    )
+
+
+def validate_train_validation_manifests(training: str | Path, validation: str | Path) -> None:
+    training_path = validate_v2_manifest_entrypoint(training)
+    validation_path = validate_v2_manifest_entrypoint(validation)
+    import nnue_dataset
+
+    validate_loader_capabilities(nnue_dataset.atomic_training_data_schemas())
+    nnue_dataset.validate_training_validation_data_paths(
+        str(training_path), str(validation_path)
+    )

--- a/atomic_v2/model.py
+++ b/atomic_v2/model.py
@@ -253,6 +253,8 @@ class AtomicLayerStacks(nn.Module):
     ) -> torch.Tensor:
         if value.ndim != 2 or value.shape[1] != 1024:
             raise ValueError("SFNNv15 layer stacks require [batch, 1024] input")
+        if bucket_indices.shape != (value.shape[0],):
+            raise ValueError("layer-stack indices must have shape [batch]")
         if bucket_indices.dtype != torch.long:
             raise TypeError("layer-stack indices must use torch.long")
         if torch.any((bucket_indices < 0) | (bucket_indices >= LAYER_STACKS)):
@@ -344,6 +346,11 @@ class AtomicNNUEV2(nn.Module):
     ) -> torch.Tensor:
         if us.ndim != 2 or us.shape[1] != 1 or them.shape != us.shape:
             raise ValueError("us and them must have shape [batch, 1]")
+        batch_size = us.shape[0]
+        if psqt_indices.shape != (batch_size,) or layer_stack_indices.shape != (
+            batch_size,
+        ):
+            raise ValueError("bucket indices must have shape [batch]")
         if psqt_indices.dtype != torch.long or layer_stack_indices.dtype != torch.long:
             raise TypeError("bucket indices must use torch.long")
         if torch.any((psqt_indices < 0) | (psqt_indices >= self.psqt_buckets)):

--- a/atomic_v2/model.py
+++ b/atomic_v2/model.py
@@ -1,0 +1,377 @@
+"""Exact HalfKAv2Atomic / SFNNv15 training graph for AtomicNNUEV2."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from .contract import (
+    ACCUMULATOR_DIMENSIONS,
+    FEATURE_DIMENSIONS,
+    FEATURE_NAME,
+    LAYER_STACKS,
+    PSQT_BUCKETS,
+)
+from .quantization import (
+    FC0_BIAS_SCALE,
+    FC0_WEIGHT_SCALE,
+    FC1_BIAS_SCALE,
+    FC1_WEIGHT_SCALE,
+    FC2_BIAS_SCALE,
+    FC2_WEIGHT_SCALE,
+    FT_ONE,
+    PSQT_WEIGHT_SCALE,
+    clip_feature_activation,
+    clip_hidden_activation,
+    fake_quantize_activation,
+    fake_quantize_output,
+    fake_quantize_weight,
+)
+
+
+def _validate_sparse_inputs(indices: torch.Tensor, values: torch.Tensor) -> None:
+    if indices.ndim != 2 or values.shape != indices.shape:
+        raise ValueError("feature indices and values must be equally shaped matrices")
+    if indices.dtype != torch.int32:
+        raise TypeError("feature indices must use torch.int32")
+    if values.dtype != torch.float32:
+        raise TypeError("feature values must use torch.float32")
+    if indices.device != values.device:
+        raise ValueError("feature indices and values must use the same device")
+    if torch.any(indices < -1):
+        raise ValueError("feature indices may only use -1 as the empty sentinel")
+
+
+def sparse_feature_sum(
+    indices: torch.Tensor,
+    values: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    *,
+    sparse_gradient: bool = False,
+) -> torch.Tensor:
+    _validate_sparse_inputs(indices, values)
+    if weight.dtype != torch.float32 or bias.dtype != torch.float32:
+        raise TypeError("feature-transformer parameters must use torch.float32")
+    if weight.device != indices.device or bias.device != indices.device:
+        raise ValueError("feature inputs and parameters must use the same device")
+
+    valid = torch.cumprod((indices != -1).to(torch.int32), dim=1).to(torch.bool)
+    safe_indices = indices.clamp_min(0).to(torch.long)
+    scaled_values = torch.where(valid, values, torch.zeros_like(values))
+    return F.embedding_bag(
+        safe_indices,
+        weight,
+        mode="sum",
+        per_sample_weights=scaled_values,
+        # Sparse gradients are safe only when `weight` is the leaf FT matrix.
+        # Fake quantization creates views/operations whose SparseCPU backward
+        # is unsupported, so that path deliberately requests a dense gradient.
+        sparse=sparse_gradient,
+    ) + bias
+
+
+class SparseFeatureTransformer(nn.Module):
+    num_features = FEATURE_DIMENSIONS
+    accumulator_dimensions = ACCUMULATOR_DIMENSIONS
+    psqt_buckets = PSQT_BUCKETS
+
+    def __init__(self, initialize: bool = True):
+        super().__init__()
+        outputs = self.accumulator_dimensions + self.psqt_buckets
+        self.weight = nn.Parameter(torch.empty(self.num_features, outputs, dtype=torch.float32))
+        self.bias = nn.Parameter(torch.empty(self.accumulator_dimensions, dtype=torch.float32))
+        self.reset_parameters(initialize)
+
+    def reset_parameters(self, initialize: bool = True) -> None:
+        with torch.no_grad():
+            if initialize:
+                bound = math.sqrt(1.0 / self.num_features)
+                self.weight.uniform_(-bound, bound)
+                self.bias.uniform_(-bound, bound)
+            else:
+                self.weight.zero_()
+                self.bias.zero_()
+            # Start PSQT from a neutral state. It is trained through the same
+            # authenticated HalfKAv2Atomic indices as the main accumulator.
+            self.weight[:, self.accumulator_dimensions :].zero_()
+
+    def _merged_parameters(
+        self, fake_quantize_weights: bool
+    ) -> tuple[torch.Tensor, torch.Tensor, bool]:
+        if fake_quantize_weights:
+            main_weight = self.weight[:, : self.accumulator_dimensions]
+            psqt_weight = self.weight[:, self.accumulator_dimensions :]
+            bias = self.bias
+            main_weight = fake_quantize_weight(main_weight, FT_ONE)
+            psqt_weight = fake_quantize_weight(psqt_weight, PSQT_WEIGHT_SCALE)
+            bias = fake_quantize_weight(bias, FT_ONE)
+            merged = torch.cat((main_weight, psqt_weight), dim=1)
+            sparse_gradient = False
+        else:
+            merged = self.weight
+            bias = self.bias
+            sparse_gradient = True
+        psqt_bias = torch.zeros(self.psqt_buckets, dtype=bias.dtype, device=bias.device)
+        return merged, torch.cat((bias, psqt_bias)), sparse_gradient
+
+    def forward(
+        self,
+        indices: torch.Tensor,
+        values: torch.Tensor,
+        fake_quantize_weights: bool,
+    ) -> torch.Tensor:
+        merged, bias, sparse_gradient = self._merged_parameters(fake_quantize_weights)
+        return sparse_feature_sum(
+            indices,
+            values,
+            merged,
+            bias,
+            sparse_gradient=sparse_gradient,
+        )
+
+    def forward_pair(
+        self,
+        white_indices: torch.Tensor,
+        white_values: torch.Tensor,
+        black_indices: torch.Tensor,
+        black_values: torch.Tensor,
+        fake_quantize_weights: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Transform both perspectives with one quantized parameter graph."""
+
+        merged, bias, sparse_gradient = self._merged_parameters(fake_quantize_weights)
+        white = sparse_feature_sum(
+            white_indices,
+            white_values,
+            merged,
+            bias,
+            sparse_gradient=sparse_gradient,
+        )
+        black = sparse_feature_sum(
+            black_indices,
+            black_values,
+            merged,
+            bias,
+            sparse_gradient=sparse_gradient,
+        )
+        return white, black
+
+
+class StackedLinear(nn.Module):
+    def __init__(
+        self, inputs: int, outputs: int, count: int, weight_scale: float, bias_scale: float
+    ):
+        super().__init__()
+        self.inputs = inputs
+        self.outputs = outputs
+        self.count = count
+        self.weight_scale = weight_scale
+        self.bias_scale = bias_scale
+        self.linear = nn.Linear(inputs, outputs * count)
+        self._repeat_first_bucket()
+
+    @torch.no_grad()
+    def _repeat_first_bucket(self) -> None:
+        weight = self.linear.weight[: self.outputs]
+        bias = self.linear.bias[: self.outputs]
+        self.linear.weight.copy_(weight.repeat(self.count, 1))
+        self.linear.bias.copy_(bias.repeat(self.count))
+
+    def _merged_parameters(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.linear.weight, self.linear.bias
+
+    def forward(
+        self,
+        value: torch.Tensor,
+        bucket_indices: torch.Tensor,
+        fake_quantize_weights: bool,
+    ) -> torch.Tensor:
+        weight, bias = self._merged_parameters()
+        if fake_quantize_weights:
+            weight = fake_quantize_weight(weight, self.weight_scale)
+            bias = fake_quantize_weight(bias, self.bias_scale)
+        broad_output = F.linear(value, weight, bias)
+        rows = broad_output.reshape(-1, self.outputs)
+        offsets = torch.arange(
+            0,
+            bucket_indices.numel() * self.count,
+            self.count,
+            device=broad_output.device,
+        )
+        return rows[bucket_indices.reshape(-1) + offsets]
+
+    @torch.no_grad()
+    def bucket_parameters(self, bucket: int) -> tuple[torch.Tensor, torch.Tensor]:
+        if bucket < 0 or bucket >= self.count:
+            raise IndexError(bucket)
+        begin = bucket * self.outputs
+        end = begin + self.outputs
+        weight, bias = self._merged_parameters()
+        return weight[begin:end].detach(), bias[begin:end].detach()
+
+
+class FactorizedStackedLinear(StackedLinear):
+    def __init__(
+        self, inputs: int, outputs: int, count: int, weight_scale: float, bias_scale: float
+    ):
+        super().__init__(inputs, outputs, count, weight_scale, bias_scale)
+        self.factorized_linear = nn.Linear(inputs, outputs)
+        with torch.no_grad():
+            self.factorized_linear.weight.zero_()
+            self.factorized_linear.bias.zero_()
+
+    def _merged_parameters(self) -> tuple[torch.Tensor, torch.Tensor]:
+        weight = self.linear.weight + self.factorized_linear.weight.repeat(self.count, 1)
+        bias = self.linear.bias + self.factorized_linear.bias.repeat(self.count)
+        return weight, bias
+
+
+class AtomicLayerStacks(nn.Module):
+    """Eight exact SFNNv15 stacks; squared paths have no wire-hash node."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc0 = FactorizedStackedLinear(
+            1024, 32, LAYER_STACKS, FC0_WEIGHT_SCALE, FC0_BIAS_SCALE
+        )
+        self.fc1 = StackedLinear(64, 32, LAYER_STACKS, FC1_WEIGHT_SCALE, FC1_BIAS_SCALE)
+        self.fc2 = StackedLinear(128, 1, LAYER_STACKS, FC2_WEIGHT_SCALE, FC2_BIAS_SCALE)
+        with torch.no_grad():
+            self.fc2.linear.bias.zero_()
+
+    def forward(
+        self,
+        value: torch.Tensor,
+        bucket_indices: torch.Tensor,
+        fake_quantize_activations: bool = True,
+        fake_quantize_weights: bool = True,
+    ) -> torch.Tensor:
+        if value.ndim != 2 or value.shape[1] != 1024:
+            raise ValueError("SFNNv15 layer stacks require [batch, 1024] input")
+        if bucket_indices.dtype != torch.long:
+            raise TypeError("layer-stack indices must use torch.long")
+        if torch.any((bucket_indices < 0) | (bucket_indices >= LAYER_STACKS)):
+            raise ValueError("layer-stack index outside [0, 7]")
+
+        fc0 = self.fc0(value, bucket_indices, fake_quantize_weights)
+        short_skip = fc0[:, -2:-1] - fc0[:, -1:]
+        fc0_squared = fc0.square()
+        fc0_linear = fc0
+        if fake_quantize_activations:
+            fc0_squared = fake_quantize_activation(fc0_squared)
+            fc0_linear = fake_quantize_activation(fc0_linear)
+        activated0 = clip_hidden_activation(torch.cat((fc0_squared, fc0_linear), dim=1))
+
+        fc1 = self.fc1(activated0, bucket_indices, fake_quantize_weights)
+        fc1_squared = fc1.square()
+        fc1_linear = fc1
+        if fake_quantize_activations:
+            fc1_squared = fake_quantize_activation(fc1_squared)
+            fc1_linear = fake_quantize_activation(fc1_linear)
+        activated1 = clip_hidden_activation(torch.cat((fc1_squared, fc1_linear), dim=1))
+
+        output = self.fc2(
+            torch.cat((activated0, activated1), dim=1),
+            bucket_indices,
+            fake_quantize_weights,
+        ) + short_skip
+        if fake_quantize_activations:
+            output = fake_quantize_output(output)
+        return output
+
+
+def pairwise_multiply(value: torch.Tensor) -> torch.Tensor:
+    if value.ndim != 2 or value.shape[1] != 2048:
+        raise ValueError("pairwise multiply requires [batch, 2048] input")
+    first_us, second_us, first_them, second_them = value.split(512, dim=1)
+    return torch.cat((first_us * second_us, first_them * second_them), dim=1)
+
+
+class AtomicNNUEV2(nn.Module):
+    feature_name = FEATURE_NAME
+    num_features = FEATURE_DIMENSIONS
+    accumulator_dimensions = ACCUMULATOR_DIMENSIONS
+    psqt_buckets = PSQT_BUCKETS
+    layer_stacks = LAYER_STACKS
+
+    def __init__(self, initialize: bool = True):
+        super().__init__()
+        self._allocate_feature_parameters(initialize)
+        self.network = AtomicLayerStacks()
+
+    def _allocate_feature_parameters(self, initialize: bool = True) -> None:
+        self.feature_transformer = SparseFeatureTransformer(initialize=initialize)
+
+    @torch.no_grad()
+    def clip_weights(self) -> None:
+        """Keep every coalesced hidden weight inside the signed int8 grid."""
+        fc0_limit = 127.0 / FC0_WEIGHT_SCALE
+        virtual = self.network.fc0.factorized_linear.weight.repeat(LAYER_STACKS, 1)
+        base = self.network.fc0.linear.weight
+        base.copy_(
+            torch.maximum(
+                torch.minimum(base, base.new_full((), fc0_limit) - virtual),
+                base.new_full((), -fc0_limit) - virtual,
+            )
+        )
+        self.network.fc1.linear.weight.clamp_(
+            -127.0 / FC1_WEIGHT_SCALE, 127.0 / FC1_WEIGHT_SCALE
+        )
+        self.network.fc2.linear.weight.clamp_(
+            -127.0 / FC2_WEIGHT_SCALE, 127.0 / FC2_WEIGHT_SCALE
+        )
+
+    def forward(
+        self,
+        us: torch.Tensor,
+        them: torch.Tensor,
+        white_indices: torch.Tensor,
+        white_values: torch.Tensor,
+        black_indices: torch.Tensor,
+        black_values: torch.Tensor,
+        psqt_indices: torch.Tensor,
+        layer_stack_indices: torch.Tensor,
+        fake_quantize_activations: bool = True,
+        fake_quantize_weights: bool = True,
+    ) -> torch.Tensor:
+        if us.ndim != 2 or us.shape[1] != 1 or them.shape != us.shape:
+            raise ValueError("us and them must have shape [batch, 1]")
+        if psqt_indices.dtype != torch.long or layer_stack_indices.dtype != torch.long:
+            raise TypeError("bucket indices must use torch.long")
+        if torch.any((psqt_indices < 0) | (psqt_indices >= self.psqt_buckets)):
+            raise ValueError("PSQT bucket index outside [0, 7]")
+
+        white, black = self.feature_transformer.forward_pair(
+            white_indices,
+            white_values,
+            black_indices,
+            black_values,
+            fake_quantize_weights,
+        )
+        white_main, white_psqt = white.split(
+            (self.accumulator_dimensions, self.psqt_buckets), dim=1
+        )
+        black_main, black_psqt = black.split(
+            (self.accumulator_dimensions, self.psqt_buckets), dim=1
+        )
+
+        white_bucket = white_psqt.gather(1, psqt_indices.reshape(-1, 1))
+        black_bucket = black_psqt.gather(1, psqt_indices.reshape(-1, 1))
+        side_ordered = us * torch.cat((white_main, black_main), dim=1) + them * torch.cat(
+            (black_main, white_main), dim=1
+        )
+        transformed = pairwise_multiply(clip_feature_activation(side_ordered))
+        if fake_quantize_activations:
+            transformed = fake_quantize_activation(transformed)
+
+        positional = (white_bucket - black_bucket) * (us - 0.5)
+        return self.network(
+            transformed,
+            layer_stack_indices,
+            fake_quantize_activations,
+            fake_quantize_weights,
+        ) + positional

--- a/atomic_v2/model.py
+++ b/atomic_v2/model.py
@@ -260,6 +260,9 @@ class AtomicLayerStacks(nn.Module):
 
         fc0 = self.fc0(value, bucket_indices, fake_quantize_weights)
         short_skip = fc0[:, -2:-1] - fc0[:, -1:]
+        # Deliberately square the signed pre-activation before clipping. This
+        # is the exact SqrClippedReLU order used by the engine and the pinned
+        # official trainer; negative inputs therefore contribute on this path.
         fc0_squared = fc0.square()
         fc0_linear = fc0
         if fake_quantize_activations:

--- a/atomic_v2/model.py
+++ b/atomic_v2/model.py
@@ -28,6 +28,7 @@ from .quantization import (
     clip_hidden_activation,
     fake_quantize_activation,
     fake_quantize_output,
+    fake_quantize_psqt_output,
     fake_quantize_weight,
 )
 
@@ -368,7 +369,9 @@ class AtomicNNUEV2(nn.Module):
         if fake_quantize_activations:
             transformed = fake_quantize_activation(transformed)
 
-        positional = (white_bucket - black_bucket) * (us - 0.5)
+        positional = fake_quantize_psqt_output(
+            (white_bucket - black_bucket) * (us - 0.5)
+        )
         return self.network(
             transformed,
             layer_stack_indices,

--- a/atomic_v2/quantization.py
+++ b/atomic_v2/quantization.py
@@ -1,0 +1,50 @@
+"""SFNNv15 fake quantization and export scales."""
+
+from __future__ import annotations
+
+import torch
+
+
+FT_ONE = 256.0
+FT_MAX = 255.0
+HIDDEN_ONE = 128.0
+HIDDEN_MAX = 127.0
+NNUE_TO_SCORE = 600.0
+OUTPUT_SCALE = 16.0
+
+FC0_WEIGHT_SCALE = 128.0
+FC1_WEIGHT_SCALE = 64.0
+FC2_WEIGHT_SCALE = 128.0
+FC0_BIAS_SCALE = FC0_WEIGHT_SCALE * HIDDEN_ONE
+FC1_BIAS_SCALE = FC1_WEIGHT_SCALE * HIDDEN_ONE
+FC2_BIAS_SCALE = FC2_WEIGHT_SCALE * HIDDEN_ONE
+PSQT_WEIGHT_SCALE = NNUE_TO_SCORE * OUTPUT_SCALE
+
+
+def fake_quantize_weight(value: torch.Tensor, scale: float) -> torch.Tensor:
+    hard = value.mul(scale).round().div(scale).detach()
+    return hard + (value - value.detach())
+
+
+def fake_quantize_activation(value: torch.Tensor, scale: float = HIDDEN_ONE) -> torch.Tensor:
+    # Engine activations truncate; the epsilon protects exact grid values from
+    # floating point representation noise.
+    hard = value.mul(scale).add(1e-5).floor().div(scale).detach()
+    return hard + (value - value.detach())
+
+
+def clip_feature_activation(value: torch.Tensor) -> torch.Tensor:
+    return value.clamp(0.0, FT_MAX / FT_ONE)
+
+
+def clip_hidden_activation(value: torch.Tensor) -> torch.Tensor:
+    return value.clamp(0.0, HIDDEN_MAX / HIDDEN_ONE)
+
+
+def fake_quantize_output(value: torch.Tensor) -> torch.Tensor:
+    multiplier = int(NNUE_TO_SCORE * OUTPUT_SCALE)
+    denominator = int(HIDDEN_ONE * FC2_WEIGHT_SCALE * 2.0)
+    integer_value = torch.round(value * denominator).to(torch.int64)
+    quantized = torch.div(integer_value * multiplier, denominator, rounding_mode="trunc")
+    hard = quantized.to(value.dtype) / float(multiplier)
+    return hard.detach() + (value - value.detach())

--- a/atomic_v2/quantization.py
+++ b/atomic_v2/quantization.py
@@ -48,3 +48,14 @@ def fake_quantize_output(value: torch.Tensor) -> torch.Tensor:
     quantized = torch.div(integer_value * multiplier, denominator, rounding_mode="trunc")
     hard = quantized.to(value.dtype) / float(multiplier)
     return hard.detach() + (value - value.detach())
+
+
+def fake_quantize_psqt_output(value: torch.Tensor) -> torch.Tensor:
+    """Match C++ signed integer PSQT division while preserving gradients."""
+
+    # Recover the pre-division integer. Truncating `value * 9600` directly is
+    # not stable in float32 (for example, -49 may be represented as -48.999996).
+    twice_raw = torch.round(value * (2.0 * PSQT_WEIGHT_SCALE)).to(torch.int64)
+    raw = torch.div(twice_raw, 2, rounding_mode="trunc")
+    hard = raw.to(value.dtype) / PSQT_WEIGHT_SCALE
+    return hard.detach() + (value - value.detach())

--- a/atomic_v2/schema/atomic-nnue-v2.json
+++ b/atomic_v2/schema/atomic-nnue-v2.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": 1,
+  "schema_id": "atomic-nnue-dual-backend-v1",
+  "variant": "atomic",
+  "byte_order": "little-endian",
+  "backends": {
+    "legacy-atomic-v1": {
+      "file_version": "0x7AF32F20",
+      "feature_set": "HalfKAv2Atomic",
+      "feature_dimensions": 45056,
+      "accumulator_dimensions_per_perspective": 512,
+      "feature_transformer_output_dimensions": 1024,
+      "feature_transformer_hash_xor": 1024,
+      "feature_set_hash": "0x5F234CB8",
+      "feature_transformer_hash": "0x5F2348B8",
+      "architecture_hash": "0x633376CA",
+      "network_hash": "0x3C103E72",
+      "psqt_buckets": 8,
+      "layer_stacks": 8,
+      "topology": {
+        "fc0": {
+          "input_dimensions": 1024,
+          "output_dimensions": 16
+        },
+        "fc1": {
+          "input_dimensions": 16,
+          "output_dimensions": 32
+        },
+        "fc2": {
+          "input_dimensions": 32,
+          "output_dimensions": 1
+        },
+        "activation_paths": {
+          "after_fc0": [
+            "clipped-relu"
+          ],
+          "after_fc1": [
+            "clipped-relu"
+          ]
+        }
+      }
+    },
+    "atomic-nnue-v2": {
+      "file_version": "0xA70C0002",
+      "feature_set": "HalfKAv2Atomic",
+      "feature_dimensions": 45056,
+      "accumulator_dimensions_per_perspective": 1024,
+      "feature_transformer_output_dimensions": 1024,
+      "feature_transformer_hash_xor": 2048,
+      "feature_set_hash": "0x5F234CB8",
+      "feature_transformer_hash": "0x5F2344B8",
+      "architecture_hash": "0x63337116",
+      "network_hash": "0x3C1035AE",
+      "psqt_buckets": 8,
+      "layer_stacks": 8,
+      "pairwise_multiply": {
+        "input_dimensions_per_perspective": 1024,
+        "half_dimensions": 512,
+        "output_dimensions_per_perspective": 512,
+        "concatenated_output_dimensions": 1024
+      },
+      "topology": {
+        "fc0": {
+          "input_dimensions": 1024,
+          "output_dimensions": 32
+        },
+        "fc1": {
+          "input_dimensions": 64,
+          "output_dimensions": 32
+        },
+        "fc2": {
+          "input_dimensions": 128,
+          "output_dimensions": 1
+        },
+        "activation_paths": {
+          "after_fc0": [
+            "squared-clipped-relu",
+            "clipped-relu"
+          ],
+          "after_fc1": [
+            "squared-clipped-relu",
+            "clipped-relu"
+          ]
+        },
+        "fc0_skip_indices": [
+          30,
+          31
+        ],
+        "fc0_skip_coefficients": [
+          1,
+          -1
+        ],
+        "output_scaling": {
+          "hidden_one": 128,
+          "weight_scale_bits": 6,
+          "output_scale": 16,
+          "network_unit_scale": 600,
+          "multiplier": 9600,
+          "denominator": 16384
+        }
+      }
+    }
+  }
+}

--- a/atomic_v2/serialization.py
+++ b/atomic_v2/serialization.py
@@ -1,0 +1,707 @@
+"""Strict AtomicNNUEV2 reader/writer.
+
+Only V2 is accepted here. Legacy V1 remains available through the historical
+root serializer and is never silently converted by this package.
+"""
+
+from __future__ import annotations
+
+import io
+import shutil
+import struct
+import tempfile
+from typing import BinaryIO, Iterable
+
+import numpy as np
+import torch
+
+from .contract import (
+    ACCUMULATOR_DIMENSIONS,
+    ARCHITECTURE_HASH,
+    FEATURE_DIMENSIONS,
+    FEATURE_TRANSFORMER_HASH,
+    FILE_VERSION,
+    LAYER_STACKS,
+    MAX_DESCRIPTION_BYTES,
+    NETWORK_HASH,
+    PSQT_BUCKETS,
+)
+from .model import AtomicNNUEV2
+from .quantization import (
+    FC0_BIAS_SCALE,
+    FC0_WEIGHT_SCALE,
+    FC1_BIAS_SCALE,
+    FC1_WEIGHT_SCALE,
+    FC2_BIAS_SCALE,
+    FC2_WEIGHT_SCALE,
+    FT_ONE,
+    PSQT_WEIGHT_SCALE,
+)
+
+
+LEB128_MAGIC = b"COMPRESSED_LEB128"
+DEFAULT_DESCRIPTION = (
+    "AtomicNNUEV2 trained with Belzedar94/variant-nnue-pytorch atomic branch."
+)
+
+
+class AtomicV2FormatError(ValueError):
+    """A network is truncated, malformed, non-canonical, or incompatible."""
+
+
+def _signed_dtype(dtype: np.dtype | str) -> np.dtype:
+    dtype = np.dtype(dtype)
+    if dtype.kind != "i" or dtype.itemsize not in (1, 2, 4):
+        raise TypeError("Atomic V2 SLEB arrays require signed i8, i16, or i32 values")
+    return dtype.newbyteorder("<")
+
+
+def _encode_one(value: int) -> bytes:
+    output = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        done = (value == 0 and (byte & 0x40) == 0) or (
+            value == -1 and (byte & 0x40) != 0
+        )
+        output.append(byte if done else byte | 0x80)
+        if done:
+            return bytes(output)
+
+
+def encode_signed_leb128(values: Iterable[int] | np.ndarray, dtype: np.dtype | str) -> bytes:
+    dtype = _signed_dtype(dtype)
+    limits = np.iinfo(dtype)
+    output = bytearray()
+    for raw_value in values:
+        value = int(raw_value)
+        if value < limits.min or value > limits.max:
+            raise AtomicV2FormatError(
+                f"SLEB value {value} is out of range for {dtype.name}"
+            )
+        output.extend(_encode_one(value))
+    return bytes(output)
+
+
+def _encode_numpy_signed_leb128(values: np.ndarray) -> bytes:
+    """Vectorized canonical SLEB encoder used for production-sized FT chunks."""
+    values = np.asarray(values)
+    dtype = _signed_dtype(values.dtype)
+    flat = values.reshape(-1).astype(np.int64, copy=False)
+    if flat.size == 0:
+        return b""
+    max_bytes = (dtype.itemsize * 8 + 6) // 7
+    encoded = np.zeros((flat.size, max_bytes), dtype=np.uint8)
+    lengths = np.zeros(flat.size, dtype=np.uint8)
+    active = np.ones(flat.size, dtype=bool)
+    current = flat.copy()
+    for column in range(max_bytes):
+        byte = (current & 0x7F).astype(np.uint8)
+        shifted = current >> 7
+        done = active & (
+            ((shifted == 0) & ((byte & 0x40) == 0))
+            | ((shifted == -1) & ((byte & 0x40) != 0))
+        )
+        encoded[active, column] = byte[active] | np.where(done[active], 0, 0x80).astype(
+            np.uint8
+        )
+        lengths[done] = column + 1
+        active &= ~done
+        current = shifted
+    if np.any(active):
+        raise AtomicV2FormatError(f"signed LEB128 value is out of range for {dtype.name}")
+    mask = np.arange(max_bytes, dtype=np.uint8)[None, :] < lengths[:, None]
+    return encoded[mask].tobytes()
+
+
+def decode_signed_leb128(
+    payload: bytes | bytearray | memoryview,
+    count: int,
+    dtype: np.dtype | str,
+) -> np.ndarray:
+    dtype = _signed_dtype(dtype)
+    if count < 0:
+        raise ValueError("count must be non-negative")
+    data = memoryview(payload).cast("B")
+    limits = np.iinfo(dtype)
+    max_bytes = (dtype.itemsize * 8 + 6) // 7
+    output = np.empty(count, dtype=dtype)
+    position = 0
+
+    for index in range(count):
+        start = position
+        decoded = 0
+        shift = 0
+        terminal_byte = None
+        for used in range(1, max_bytes + 1):
+            if position >= len(data):
+                raise AtomicV2FormatError("truncated signed LEB128 value")
+            byte = int(data[position])
+            position += 1
+            decoded |= (byte & 0x7F) << shift
+            shift += 7
+            if (byte & 0x80) == 0:
+                terminal_byte = byte
+                break
+            if used == max_bytes:
+                raise AtomicV2FormatError(
+                    f"signed LEB128 value is out of range for {dtype.name}"
+                )
+        if terminal_byte is None:
+            raise AtomicV2FormatError("truncated signed LEB128 value")
+        if terminal_byte & 0x40:
+            decoded |= -(1 << shift)
+        if decoded < limits.min or decoded > limits.max:
+            raise AtomicV2FormatError(
+                f"signed LEB128 value is out of range for {dtype.name}"
+            )
+        encoded = bytes(data[start:position])
+        if encoded != _encode_one(decoded):
+            raise AtomicV2FormatError("non-canonical signed LEB128 value")
+        output[index] = decoded
+
+    if position != len(data):
+        raise AtomicV2FormatError("trailing bytes in signed LEB128 payload")
+    return output
+
+
+def _decode_complete_numpy_sleb(payload: bytes, dtype: np.dtype) -> np.ndarray:
+    """Decode a payload ending on a value boundary with bounded Numpy memory."""
+    dtype = _signed_dtype(dtype)
+    if not payload:
+        return np.empty(0, dtype=dtype)
+    data = np.frombuffer(payload, dtype=np.uint8)
+    ends = np.flatnonzero((data & 0x80) == 0)
+    if ends.size == 0 or int(ends[-1]) != data.size - 1:
+        raise AtomicV2FormatError("truncated signed LEB128 value")
+    starts = np.empty_like(ends)
+    starts[0] = 0
+    starts[1:] = ends[:-1] + 1
+    lengths = ends - starts + 1
+    max_bytes = (dtype.itemsize * 8 + 6) // 7
+    if np.any(lengths > max_bytes):
+        raise AtomicV2FormatError(
+            f"signed LEB128 value is out of range for {dtype.name}"
+        )
+
+    decoded = np.zeros(ends.size, dtype=np.int64)
+    for column in range(max_bytes):
+        selected = lengths > column
+        if not np.any(selected):
+            break
+        bytes_at_column = data[starts[selected] + column]
+        decoded[selected] |= (bytes_at_column & 0x7F).astype(np.int64) << (7 * column)
+    terminal = data[ends]
+    signed = (terminal & 0x40) != 0
+    decoded[signed] |= -(1 << (7 * lengths[signed]))
+
+    limits = np.iinfo(dtype)
+    if np.any(decoded < limits.min) or np.any(decoded > limits.max):
+        raise AtomicV2FormatError(
+            f"signed LEB128 value is out of range for {dtype.name}"
+        )
+
+    expected_lengths = np.zeros(decoded.size, dtype=lengths.dtype)
+    active = np.ones(decoded.size, dtype=bool)
+    current = decoded.copy()
+    for column in range(max_bytes):
+        byte = current & 0x7F
+        shifted = current >> 7
+        done = active & (
+            ((shifted == 0) & ((byte & 0x40) == 0))
+            | ((shifted == -1) & ((byte & 0x40) != 0))
+        )
+        expected_lengths[done] = column + 1
+        active &= ~done
+        current = shifted
+    if np.any(active):
+        raise AtomicV2FormatError(
+            f"signed LEB128 value is out of range for {dtype.name}"
+        )
+    if not np.array_equal(lengths, expected_lengths):
+        raise AtomicV2FormatError("non-canonical signed LEB128 value")
+    return decoded.astype(dtype, copy=False)
+
+
+def _write_all(stream: BinaryIO, data: bytes | bytearray | memoryview, label: str) -> None:
+    written = stream.write(data)
+    if written is not None and written != len(data):
+        raise AtomicV2FormatError(f"short write while writing {label}")
+
+
+def _read_exact(stream: BinaryIO, size: int, label: str) -> bytes:
+    data = stream.read(size)
+    if data is None or len(data) != size:
+        raise AtomicV2FormatError(f"truncated {label}")
+    return data
+
+
+def _read_u32(stream: BinaryIO, label: str) -> int:
+    return struct.unpack("<I", _read_exact(stream, 4, label))[0]
+
+
+def _write_u32(stream: BinaryIO, value: int) -> None:
+    _write_all(stream, struct.pack("<I", value), "integer")
+
+
+def write_compressed_array(stream: BinaryIO, values: np.ndarray) -> None:
+    values = np.asarray(values)
+    dtype = _signed_dtype(values.dtype)
+    payload = encode_signed_leb128(values.reshape(-1), dtype)
+    if len(payload) > 0xFFFFFFFF:
+        raise AtomicV2FormatError("compressed payload exceeds the V2 uint32 length")
+    _write_all(stream, LEB128_MAGIC, "compressed magic")
+    _write_u32(stream, len(payload))
+    _write_all(stream, payload, "compressed payload")
+
+
+def _write_compressed_tensor(
+    stream: BinaryIO,
+    tensor: torch.Tensor,
+    scale: float,
+    dtype: np.dtype | str,
+    *,
+    chunk_elements: int = 1 << 18,
+) -> None:
+    dtype = _signed_dtype(dtype)
+    limits = np.iinfo(dtype)
+    source = tensor.detach()
+
+    if source.numel() <= 0xFFFFFFFF and int(torch.count_nonzero(source).item()) == 0:
+        # Canonical SLEB(0) is one zero byte. Controlled fixtures and freshly
+        # zero-initialized PSQT tensors can therefore be streamed without a
+        # 46-million-value Python/Numpy encoding pass or a temporary spool.
+        _write_all(stream, LEB128_MAGIC, "compressed magic")
+        _write_u32(stream, source.numel())
+        zero_block = bytes(1 << 20)
+        remaining = source.numel()
+        while remaining:
+            size = min(remaining, len(zero_block))
+            _write_all(stream, zero_block[:size], "compressed zero payload")
+            remaining -= size
+        return
+
+    def chunks():
+        if source.is_contiguous():
+            flat = source.reshape(-1)
+            for offset in range(0, flat.numel(), chunk_elements):
+                yield flat[offset : offset + chunk_elements].cpu()
+            return
+        if source.ndim == 2:
+            # The main FT slice is [45056, :1024] of a [45056, 1032]
+            # parameter. Flattening it directly would materialize an extra
+            # ~184 MiB copy. Keep the wire feature-major while copying only a
+            # bounded number of complete rows at a time.
+            columns = source.shape[1]
+            rows_per_chunk = max(1, chunk_elements // columns)
+            for row in range(0, source.shape[0], rows_per_chunk):
+                yield source[row : row + rows_per_chunk].contiguous().reshape(-1).cpu()
+            return
+        flat = source.contiguous().reshape(-1)
+        for offset in range(0, flat.numel(), chunk_elements):
+            yield flat[offset : offset + chunk_elements].cpu()
+
+    with tempfile.SpooledTemporaryFile(max_size=8 << 20) as encoded:
+        byte_count = 0
+        for chunk in chunks():
+            rounded = torch.round(chunk * scale)
+            if not torch.isfinite(rounded).all():
+                raise AtomicV2FormatError("network contains a non-finite parameter")
+            minimum = int(rounded.min().item()) if rounded.numel() else 0
+            maximum = int(rounded.max().item()) if rounded.numel() else 0
+            if minimum < -limits.max or maximum > limits.max:
+                raise AtomicV2FormatError(
+                    f"quantized parameter range [{minimum}, {maximum}] exceeds {dtype.name}"
+                )
+            array = rounded.numpy().astype(dtype, copy=False)
+            payload = _encode_numpy_signed_leb128(array)
+            encoded.write(payload)
+            byte_count += len(payload)
+            if byte_count > 0xFFFFFFFF:
+                raise AtomicV2FormatError("compressed payload exceeds the V2 uint32 length")
+        _write_all(stream, LEB128_MAGIC, "compressed magic")
+        _write_u32(stream, byte_count)
+        encoded.seek(0)
+        shutil.copyfileobj(encoded, stream, length=1 << 20)
+
+
+def read_compressed_array(
+    stream: BinaryIO,
+    count: int,
+    dtype: np.dtype | str,
+) -> np.ndarray:
+    dtype = _signed_dtype(dtype)
+    magic = _read_exact(stream, len(LEB128_MAGIC), "compressed magic")
+    if magic != LEB128_MAGIC:
+        raise AtomicV2FormatError("invalid compressed magic")
+    byte_count = _read_u32(stream, "compressed payload length")
+    max_bytes = (dtype.itemsize * 8 + 6) // 7
+    if byte_count < count or byte_count > count * max_bytes:
+        raise AtomicV2FormatError(
+            f"invalid compressed length {byte_count} for {count} {dtype.name} values"
+        )
+    output = np.empty(count, dtype=dtype)
+    output_offset = 0
+    remaining = byte_count
+    pending = b""
+    while remaining:
+        block = _read_exact(stream, min(remaining, 1 << 20), "compressed payload")
+        remaining -= len(block)
+        data = pending + block
+        byte_view = np.frombuffer(data, dtype=np.uint8)
+        terminal = np.flatnonzero((byte_view & 0x80) == 0)
+        if terminal.size == 0:
+            if len(data) > max_bytes:
+                raise AtomicV2FormatError(
+                    f"signed LEB128 value is out of range for {dtype.name}"
+                )
+            pending = data
+            continue
+        boundary = int(terminal[-1]) + 1
+        complete = data[:boundary]
+        pending = data[boundary:]
+        if len(pending) >= max_bytes:
+            raise AtomicV2FormatError(
+                f"signed LEB128 value is out of range for {dtype.name}"
+            )
+
+        if complete.count(0) == len(complete):
+            values = np.zeros(len(complete), dtype=dtype)
+        else:
+            values = _decode_complete_numpy_sleb(complete, dtype)
+        end = output_offset + values.size
+        if end > count:
+            raise AtomicV2FormatError("trailing values in signed LEB128 payload")
+        output[output_offset:end] = values
+        output_offset = end
+
+    if pending:
+        raise AtomicV2FormatError("truncated signed LEB128 value")
+    if output_offset != count:
+        raise AtomicV2FormatError(
+            f"truncated signed LEB128 payload: decoded {output_offset} of {count} values"
+        )
+    return output
+
+
+def _copy_flat_values(
+    target: torch.Tensor,
+    offset: int,
+    values: np.ndarray,
+    scale: float,
+) -> None:
+    if values.size == 0:
+        return
+    converted = torch.from_numpy(values.astype(np.float32)).div_(scale)
+    if target.ndim == 1:
+        target[offset : offset + converted.numel()].copy_(converted)
+        return
+    if target.ndim != 2:
+        raise AtomicV2FormatError("streaming tensor target must be one- or two-dimensional")
+    columns = target.shape[1]
+    cursor = 0
+    row, column = divmod(offset, columns)
+    if column:
+        width = min(columns - column, converted.numel())
+        target[row, column : column + width].copy_(converted[:width])
+        cursor += width
+        row += 1
+    remaining = converted.numel() - cursor
+    complete_rows = remaining // columns
+    if complete_rows:
+        end = cursor + complete_rows * columns
+        target[row : row + complete_rows].copy_(
+            converted[cursor:end].reshape(complete_rows, columns)
+        )
+        cursor = end
+        row += complete_rows
+    if cursor < converted.numel():
+        target[row, : converted.numel() - cursor].copy_(converted[cursor:])
+
+
+def _read_compressed_tensor_into(
+    stream: BinaryIO,
+    target: torch.Tensor,
+    scale: float,
+    dtype: np.dtype | str,
+) -> None:
+    dtype = _signed_dtype(dtype)
+    count = target.numel()
+    magic = _read_exact(stream, len(LEB128_MAGIC), "compressed magic")
+    if magic != LEB128_MAGIC:
+        raise AtomicV2FormatError("invalid compressed magic")
+    byte_count = _read_u32(stream, "compressed payload length")
+    max_bytes = (dtype.itemsize * 8 + 6) // 7
+    if byte_count < count or byte_count > count * max_bytes:
+        raise AtomicV2FormatError(
+            f"invalid compressed length {byte_count} for {count} {dtype.name} values"
+        )
+
+    output_offset = 0
+    remaining = byte_count
+    pending = b""
+    while remaining:
+        block = _read_exact(stream, min(remaining, 1 << 20), "compressed payload")
+        remaining -= len(block)
+        data = pending + block
+        byte_view = np.frombuffer(data, dtype=np.uint8)
+        terminal = np.flatnonzero((byte_view & 0x80) == 0)
+        if terminal.size == 0:
+            if len(data) > max_bytes:
+                raise AtomicV2FormatError(
+                    f"signed LEB128 value is out of range for {dtype.name}"
+                )
+            pending = data
+            continue
+        boundary = int(terminal[-1]) + 1
+        complete = data[:boundary]
+        pending = data[boundary:]
+        if len(pending) >= max_bytes:
+            raise AtomicV2FormatError(
+                f"signed LEB128 value is out of range for {dtype.name}"
+            )
+
+        if complete.count(0) == len(complete):
+            value_count = len(complete)
+            end = output_offset + value_count
+            if end > count:
+                raise AtomicV2FormatError("trailing values in signed LEB128 payload")
+            target_flat_zero = target if target.ndim == 1 else None
+            if target_flat_zero is not None:
+                target_flat_zero[output_offset:end].zero_()
+            else:
+                _copy_flat_values(
+                    target, output_offset, np.zeros(value_count, dtype=dtype), scale
+                )
+            output_offset = end
+            continue
+
+        values = _decode_complete_numpy_sleb(complete, dtype)
+        end = output_offset + values.size
+        if end > count:
+            raise AtomicV2FormatError("trailing values in signed LEB128 payload")
+        _copy_flat_values(target, output_offset, values, scale)
+        output_offset = end
+
+    if pending:
+        raise AtomicV2FormatError("truncated signed LEB128 value")
+    if output_offset != count:
+        raise AtomicV2FormatError(
+            f"truncated signed LEB128 payload: decoded {output_offset} of {count} values"
+        )
+
+
+def write_header(stream: BinaryIO, description: str = DEFAULT_DESCRIPTION) -> None:
+    if not isinstance(description, str):
+        raise TypeError("description must be text")
+    encoded = description.encode("utf-8")
+    if len(encoded) > MAX_DESCRIPTION_BYTES:
+        raise AtomicV2FormatError("description length exceeds 1 MiB")
+    _write_u32(stream, FILE_VERSION)
+    _write_u32(stream, NETWORK_HASH)
+    _write_u32(stream, len(encoded))
+    _write_all(stream, encoded, "description")
+
+
+def read_header(stream: BinaryIO) -> str:
+    version = _read_u32(stream, "file version")
+    if version != FILE_VERSION:
+        raise AtomicV2FormatError(
+            f"incompatible file version 0x{version:08X}; expected Atomic V2 0x{FILE_VERSION:08X}"
+        )
+    network_hash = _read_u32(stream, "network hash")
+    if network_hash != NETWORK_HASH:
+        raise AtomicV2FormatError(
+            f"incompatible network hash 0x{network_hash:08X}; expected 0x{NETWORK_HASH:08X}"
+        )
+    description_length = _read_u32(stream, "description length")
+    if description_length > MAX_DESCRIPTION_BYTES:
+        raise AtomicV2FormatError("invalid description length")
+    encoded = _read_exact(stream, description_length, "description")
+    try:
+        return encoded.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise AtomicV2FormatError("description is not valid UTF-8") from error
+
+
+def _quantized_numpy(
+    tensor: torch.Tensor,
+    scale: float,
+    dtype: np.dtype | str,
+    label: str,
+) -> np.ndarray:
+    dtype = _signed_dtype(dtype)
+    rounded = torch.round(tensor.detach().cpu() * scale)
+    if not torch.isfinite(rounded).all():
+        raise AtomicV2FormatError(f"{label} contains a non-finite parameter")
+    limits = np.iinfo(dtype)
+    if rounded.numel():
+        minimum = int(rounded.min().item())
+        maximum = int(rounded.max().item())
+        if minimum < -limits.max or maximum > limits.max:
+            raise AtomicV2FormatError(
+                f"{label} range [{minimum}, {maximum}] exceeds {dtype.name}"
+            )
+    return rounded.numpy().astype(dtype, copy=False)
+
+
+def _write_fc_layer(
+    stream: BinaryIO,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    weight_scale: float,
+    bias_scale: float,
+    label: str,
+) -> None:
+    bias_array = _quantized_numpy(bias, bias_scale, "<i4", f"{label} bias")
+    weight_array = _quantized_numpy(weight, weight_scale, "i1", f"{label} weight")
+    _write_all(stream, bias_array.tobytes(order="C"), f"{label} bias")
+    _write_all(stream, weight_array.tobytes(order="C"), f"{label} weight")
+
+
+def _validate_model_shapes(model: AtomicNNUEV2) -> None:
+    try:
+        tensors = (
+            (
+                "feature-transformer weight",
+                model.feature_transformer.weight,
+                (FEATURE_DIMENSIONS, ACCUMULATOR_DIMENSIONS + PSQT_BUCKETS),
+            ),
+            (
+                "feature-transformer bias",
+                model.feature_transformer.bias,
+                (ACCUMULATOR_DIMENSIONS,),
+            ),
+            ("fc0 weight", model.network.fc0.linear.weight, (LAYER_STACKS * 32, 1024)),
+            ("fc0 bias", model.network.fc0.linear.bias, (LAYER_STACKS * 32,)),
+            (
+                "fc0 factorized weight",
+                model.network.fc0.factorized_linear.weight,
+                (32, 1024),
+            ),
+            ("fc0 factorized bias", model.network.fc0.factorized_linear.bias, (32,)),
+            ("fc1 weight", model.network.fc1.linear.weight, (LAYER_STACKS * 32, 64)),
+            ("fc1 bias", model.network.fc1.linear.bias, (LAYER_STACKS * 32,)),
+            ("fc2 weight", model.network.fc2.linear.weight, (LAYER_STACKS, 128)),
+            ("fc2 bias", model.network.fc2.linear.bias, (LAYER_STACKS,)),
+        )
+    except AttributeError as error:
+        raise AtomicV2FormatError("model is missing a V2 contract tensor") from error
+    for label, tensor, expected_shape in tensors:
+        if not isinstance(tensor, torch.Tensor):
+            raise AtomicV2FormatError(f"{label} is not a tensor")
+        if tuple(tensor.shape) != expected_shape:
+            raise AtomicV2FormatError(
+                f"{label} shape {tuple(tensor.shape)} does not match {expected_shape}"
+            )
+
+
+def write_nnue(
+    stream: BinaryIO,
+    model: AtomicNNUEV2,
+    description: str = DEFAULT_DESCRIPTION,
+) -> None:
+    if not isinstance(model, AtomicNNUEV2):
+        raise TypeError("Atomic V2 writer accepts only AtomicNNUEV2 models")
+    _validate_model_shapes(model)
+
+    write_header(stream, description)
+    _write_u32(stream, FEATURE_TRANSFORMER_HASH)
+    transformer = model.feature_transformer
+    _write_compressed_tensor(stream, transformer.bias, FT_ONE, "<i2")
+    _write_compressed_tensor(
+        stream, transformer.weight[:, :1024], FT_ONE, "<i2"
+    )
+    _write_compressed_tensor(
+        stream, transformer.weight[:, 1024:], PSQT_WEIGHT_SCALE, "<i4"
+    )
+
+    for bucket in range(LAYER_STACKS):
+        _write_u32(stream, ARCHITECTURE_HASH)
+        fc0_weight, fc0_bias = model.network.fc0.bucket_parameters(bucket)
+        fc1_weight, fc1_bias = model.network.fc1.bucket_parameters(bucket)
+        fc2_weight, fc2_bias = model.network.fc2.bucket_parameters(bucket)
+        _write_fc_layer(
+            stream, fc0_weight, fc0_bias, FC0_WEIGHT_SCALE, FC0_BIAS_SCALE, "fc0"
+        )
+        _write_fc_layer(
+            stream, fc1_weight, fc1_bias, FC1_WEIGHT_SCALE, FC1_BIAS_SCALE, "fc1"
+        )
+        _write_fc_layer(
+            stream, fc2_weight, fc2_bias, FC2_WEIGHT_SCALE, FC2_BIAS_SCALE, "fc2"
+        )
+
+
+def _read_fc_layer(
+    stream: BinaryIO,
+    outputs: int,
+    inputs: int,
+    weight_scale: float,
+    bias_scale: float,
+    label: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    bias = np.frombuffer(_read_exact(stream, outputs * 4, f"{label} bias"), dtype="<i4").copy()
+    weight = np.frombuffer(
+        _read_exact(stream, outputs * inputs, f"{label} weight"), dtype="i1"
+    ).copy().reshape(outputs, inputs)
+    return (
+        torch.from_numpy(weight.astype(np.float32)).div(weight_scale),
+        torch.from_numpy(bias.astype(np.float32)).div(bias_scale),
+    )
+
+
+def read_nnue(stream: BinaryIO) -> tuple[AtomicNNUEV2, str]:
+    # Header validation deliberately precedes the 180+ MiB production model
+    # allocation, so V1 and incompatible files fail cheaply and explicitly.
+    description = read_header(stream)
+    transformer_hash = _read_u32(stream, "feature-transformer hash")
+    if transformer_hash != FEATURE_TRANSFORMER_HASH:
+        raise AtomicV2FormatError("incompatible feature-transformer hash")
+
+    model = AtomicNNUEV2(initialize=False)
+    with torch.no_grad():
+        _read_compressed_tensor_into(
+            stream, model.feature_transformer.bias, FT_ONE, "<i2"
+        )
+        _read_compressed_tensor_into(
+            stream, model.feature_transformer.weight[:, :1024], FT_ONE, "<i2"
+        )
+        _read_compressed_tensor_into(
+            stream,
+            model.feature_transformer.weight[:, 1024:],
+            PSQT_WEIGHT_SCALE,
+            "<i4",
+        )
+
+        model.network.fc0.factorized_linear.weight.zero_()
+        model.network.fc0.factorized_linear.bias.zero_()
+        for bucket in range(LAYER_STACKS):
+            architecture_hash = _read_u32(stream, f"architecture hash for bucket {bucket}")
+            if architecture_hash != ARCHITECTURE_HASH:
+                raise AtomicV2FormatError(
+                    f"incompatible architecture hash in bucket {bucket}"
+                )
+            layers = (
+                (model.network.fc0, 32, 1024, FC0_WEIGHT_SCALE, FC0_BIAS_SCALE, "fc0"),
+                (model.network.fc1, 32, 64, FC1_WEIGHT_SCALE, FC1_BIAS_SCALE, "fc1"),
+                (model.network.fc2, 1, 128, FC2_WEIGHT_SCALE, FC2_BIAS_SCALE, "fc2"),
+            )
+            for layer, outputs, inputs, weight_scale, bias_scale, label in layers:
+                layer_weight, layer_bias = _read_fc_layer(
+                    stream, outputs, inputs, weight_scale, bias_scale, label
+                )
+                begin = bucket * outputs
+                end = begin + outputs
+                layer.linear.weight[begin:end].copy_(layer_weight)
+                layer.linear.bias[begin:end].copy_(layer_bias)
+
+    trailing = stream.read(1)
+    if trailing not in (b"", None):
+        raise AtomicV2FormatError("trailing bytes after Atomic V2 network")
+    return model, description
+
+
+def dumps_header(description: str = DEFAULT_DESCRIPTION) -> bytes:
+    stream = io.BytesIO()
+    write_header(stream, description)
+    return stream.getvalue()

--- a/atomic_v2/serialization.py
+++ b/atomic_v2/serialization.py
@@ -309,7 +309,7 @@ def _write_compressed_tensor(
                 raise AtomicV2FormatError("network contains a non-finite parameter")
             minimum = int(rounded.min().item()) if rounded.numel() else 0
             maximum = int(rounded.max().item()) if rounded.numel() else 0
-            if minimum < -limits.max or maximum > limits.max:
+            if minimum < limits.min or maximum > limits.max:
                 raise AtomicV2FormatError(
                     f"quantized parameter range [{minimum}, {maximum}] exceeds {dtype.name}"
                 )
@@ -538,7 +538,7 @@ def _quantized_numpy(
     if rounded.numel():
         minimum = int(rounded.min().item())
         maximum = int(rounded.max().item())
-        if minimum < -limits.max or maximum > limits.max:
+        if minimum < limits.min or maximum > limits.max:
             raise AtomicV2FormatError(
                 f"{label} range [{minimum}, {maximum}] exceeds {dtype.name}"
             )

--- a/atomic_v2/training.py
+++ b/atomic_v2/training.py
@@ -1,0 +1,180 @@
+"""Minimal deterministic CPU training primitive for AtomicNNUEV2."""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .dataset import validate_batch
+from .model import AtomicNNUEV2
+
+
+@dataclass(frozen=True)
+class OneStepResult:
+    loss_before: float
+    loss_after: float
+    parameter_sha256: str
+
+
+def atomic_loss(
+    prediction: torch.Tensor,
+    outcome: torch.Tensor,
+    score: torch.Tensor,
+    *,
+    lambda_: float = 1.0,
+    score_input_scale: float = 410.0,
+    score_output_scale: float = 361.0,
+) -> torch.Tensor:
+    if not 0.0 <= lambda_ <= 1.0:
+        raise ValueError("lambda_ must be in [0, 1]")
+    predicted_probability = (prediction * 600.0 / score_output_scale).sigmoid()
+    evaluation_probability = (score / score_input_scale).sigmoid()
+    evaluation_loss = (evaluation_probability - predicted_probability).square().mean()
+    result_loss = (predicted_probability - outcome).square().mean()
+    return lambda_ * evaluation_loss + (1.0 - lambda_) * result_loss
+
+
+def create_optimizer(model: AtomicNNUEV2, learning_rate: float = 1.5e-3) -> torch.optim.Optimizer:
+    if learning_rate <= 0:
+        raise ValueError("learning_rate must be positive")
+    output_parameters = list(model.network.fc2.parameters())
+    output_ids = {id(parameter) for parameter in output_parameters}
+    main_parameters = [
+        parameter for parameter in model.parameters() if id(parameter) not in output_ids
+    ]
+    return torch.optim.AdamW(
+        [
+            {"params": main_parameters, "lr": learning_rate},
+            {"params": output_parameters, "lr": learning_rate / 10.0},
+        ],
+        betas=(0.9, 0.999),
+        eps=1e-7,
+        weight_decay=0.0,
+    )
+
+
+def train_batch(
+    model: AtomicNNUEV2,
+    optimizer: torch.optim.Optimizer,
+    batch: tuple[torch.Tensor, ...],
+    *,
+    lambda_: float = 1.0,
+) -> float:
+    (
+        us,
+        them,
+        white_indices,
+        white_values,
+        black_indices,
+        black_values,
+        outcome,
+        score,
+        psqt_indices,
+        layer_stack_indices,
+    ) = validate_batch(batch)
+    model.clip_weights()
+    prediction = model(
+        us,
+        them,
+        white_indices,
+        white_values,
+        black_indices,
+        black_values,
+        psqt_indices,
+        layer_stack_indices,
+    )
+    loss = atomic_loss(prediction, outcome, score, lambda_=lambda_)
+    if not torch.isfinite(loss):
+        raise FloatingPointError("Atomic V2 training loss is not finite")
+    optimizer.zero_grad(set_to_none=True)
+    loss.backward()
+    optimizer.step()
+    model.clip_weights()
+    return float(loss.detach())
+
+
+def _synthetic_batch() -> tuple[torch.Tensor, ...]:
+    us = torch.tensor([[1.0], [0.0]], dtype=torch.float32)
+    them = 1.0 - us
+    white_indices = torch.tensor(
+        [[0, 704, 1408, -1], [63, 767, 1471, -1]], dtype=torch.int32
+    )
+    black_indices = torch.tensor(
+        [[45055, 44351, 43647, -1], [44992, 44288, 43584, -1]], dtype=torch.int32
+    )
+    white_values = torch.tensor([[1.0, 1.0, 1.0, 0.0]] * 2, dtype=torch.float32)
+    black_values = white_values.clone()
+    psqt_indices = torch.tensor([7, 7], dtype=torch.long)
+    layer_stack_indices = torch.tensor([7, 7], dtype=torch.long)
+    return (
+        us,
+        them,
+        white_indices,
+        white_values,
+        black_indices,
+        black_values,
+        psqt_indices,
+        layer_stack_indices,
+    )
+
+
+def _updated_parameter_digest(model: AtomicNNUEV2, active_rows: list[int]) -> str:
+    digest = hashlib.sha256()
+    tensors = [
+        model.feature_transformer.weight.detach()[active_rows],
+        model.feature_transformer.bias.detach(),
+        *(parameter.detach() for parameter in model.network.parameters()),
+    ]
+    for tensor in tensors:
+        array = tensor.cpu().contiguous().numpy().astype(np.dtype("<f4"), copy=False)
+        digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def deterministic_cpu_one_step(seed: int = 0, learning_rate: float = 1.5e-3) -> OneStepResult:
+    """Run one production-shape CPU optimizer step and return stable evidence.
+
+    The full 45,056 x 1,032 feature matrix, fake-quantized graph and production
+    AdamW parameter groups are exercised rather than replaced with a toy net or
+    a smoke-only optimizer.
+    """
+    if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+        raise ValueError("seed must be a non-negative integer")
+    previous_threads = torch.get_num_threads()
+    deterministic_before = torch.are_deterministic_algorithms_enabled()
+    torch.set_num_threads(1)
+    torch.use_deterministic_algorithms(True)
+    try:
+        torch.manual_seed(seed)
+        model = AtomicNNUEV2(initialize=False).cpu()
+        batch = _synthetic_batch()
+        target = torch.tensor([[0.20], [-0.15]], dtype=torch.float32)
+        optimizer = create_optimizer(model, learning_rate)
+
+        model.clip_weights()
+        prediction = model(*batch)
+        loss = F.mse_loss(prediction, target)
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        optimizer.step()
+        model.clip_weights()
+
+        with torch.no_grad():
+            loss_after = F.mse_loss(model(*batch), target)
+        active_rows = [0, 63, 704, 767, 1408, 1471, 43584, 43647, 44288, 44351, 44992, 45055]
+        result = OneStepResult(
+            loss_before=float(loss.detach()),
+            loss_after=float(loss_after.detach()),
+            parameter_sha256=_updated_parameter_digest(model, active_rows),
+        )
+        del optimizer, model, prediction, loss, loss_after
+        gc.collect()
+        return result
+    finally:
+        torch.use_deterministic_algorithms(deterministic_before)
+        torch.set_num_threads(previous_threads)

--- a/docs/atomic-nnue-v2.md
+++ b/docs/atomic-nnue-v2.md
@@ -36,7 +36,18 @@ count and loss are persisted in the checkpoint and JSON summary.
 files. Both entrypoints reject implicit overwrites; neither accepts or silently
 upgrades a V1 network. The writer validates every physical tensor shape before
 emitting header bytes and is pinned to the engine's nonzero diagnostic fixture
-SHA-256 `2AF647392F7A30072C2DB29837C9175D22BA2DF450931762D0E2DE8CFE337B50`.
+SHA-256 `A14261B40D638B98257241C17DCC52DFCB5023B44F91D21C742F398183A4EA64`.
+That fixture diagnoses both main feature dimensions and PSQT buckets 0 through
+6, fixes FT biases in dimensions 2 and 514, and carries nonzero weights through
+every dense layer and both squared/linear activation paths. Bucket 7 remains
+zero; the complete integer reference ends at `fwd=18965` and controlled
+raw/public output `11112/694`.
+
+PSQT output follows the engine's signed integer contract: the perspective
+difference is divided by two with truncation toward zero. The training graph
+uses a straight-through estimator, so odd raw differences of `+1` and `-1`
+both produce zero rather than unrepresentable half-unit evaluations while
+retaining their gradient.
 
 The current strong V1 network remains appropriate as the generator's `pure`
 teacher. That does not make it a V2 initialization checkpoint.

--- a/docs/atomic-nnue-v2.md
+++ b/docs/atomic-nnue-v2.md
@@ -36,12 +36,13 @@ count and loss are persisted in the checkpoint and JSON summary.
 files. Both entrypoints reject implicit overwrites; neither accepts or silently
 upgrades a V1 network. The writer validates every physical tensor shape before
 emitting header bytes and is pinned to the engine's nonzero diagnostic fixture
-SHA-256 `A14261B40D638B98257241C17DCC52DFCB5023B44F91D21C742F398183A4EA64`.
+SHA-256 `4DEB05CFF79B5D5EBA51C560F64ED24224671C188B6C5DB27521033E587C87C6`.
 That fixture diagnoses both main feature dimensions and PSQT buckets 0 through
-6, fixes FT biases in dimensions 2 and 514, and carries nonzero weights through
-every dense layer and both squared/linear activation paths. Bucket 7 remains
-zero; the complete integer reference ends at `fwd=18965` and controlled
-raw/public output `11112/694`.
+6, activates ten paired FT dimensions across SIMD and sparse-group boundaries,
+and carries nonzero weights through every dense layer and both squared/linear
+activation paths. Its eight layer stacks have distinct raw/public outputs from
+`10587/661` through `11112/694`, detecting stack permutation or fixed-bucket
+errors. PSQT bucket 7 remains zero.
 
 PSQT output follows the engine's signed integer contract: the perspective
 difference is divided by two with truncation toward zero. The training graph

--- a/docs/atomic-nnue-v2.md
+++ b/docs/atomic-nnue-v2.md
@@ -1,0 +1,42 @@
+# AtomicNNUEV2 trainer
+
+`atomic_v2/` is an additive trainer backend. The historical root `model.py`,
+`train.py`, and `serialize.py` remain the LegacyAtomicV1 path.
+
+The backend is pinned to the engine contract from Atomic-Stockfish commit
+`0818886d77328fe25850a3187e6460adaa980316`. Its vendored JSON has Git blob
+`8a8003cbf5f7b97b50470de898ae16074aad7bca` and raw SHA-256
+`70ea8da4cdd2f209fafc25f9419d3b3f226711b00701bf2fc02587dba65b82d7`.
+The SFNNv15 topology and quantization behavior are adapted by intent from
+official `nnue-pytorch` commit
+`b8512291deb4cd18afa67003bb6bc53dd522cbf0`; orthodox `HalfKAv2_hm` and
+`FullThreats` are deliberately absent.
+
+The physical graph is HalfKAv2Atomic (45,056 real features), a 1,024-value
+accumulator per perspective, pairwise multiplication to 1,024 transformed
+values, and the SFNNv15 `1024 -> 32`, `64 -> 32`, `128 -> 1` layer stacks.
+Both squared and linear clipped activation paths and the `fc0[-2]-fc0[-1]`
+short skip are mandatory even though the legacy wire hash cannot distinguish
+all of those physical details.
+
+Use `train_atomic_v2.py` with separate atomic-bin-v2 train and validation
+manifests. The V2 entrypoint requires and preflights the canonical
+`.atbin.manifest.json` suffix, format and both schema hashes before invoking the
+dual-format native loader, so a Legacy V1 or mixed train/validation pair cannot
+silently bypass overlap validation. It then uses the loader's plural capability
+handshake and ten-tensor batch ABI, seeds before model construction, and starts
+V2 from scratch.
+
+The default batch size is 128 on CPU and 16,384 on CUDA. Validation is a
+sample-weighted aggregate up to the explicit `--validation-samples` budget
+(default 1,000,000), or to dataset EOF when shorter. The budget, actual sample
+count and loss are persisted in the checkpoint and JSON summary.
+
+`serialize_atomic_v2.py` converts only tagged V2 checkpoints and V2 network
+files. Both entrypoints reject implicit overwrites; neither accepts or silently
+upgrades a V1 network. The writer validates every physical tensor shape before
+emitting header bytes and is pinned to the engine's nonzero diagnostic fixture
+SHA-256 `2AF647392F7A30072C2DB29837C9175D22BA2DF450931762D0E2DE8CFE337B50`.
+
+The current strong V1 network remains appropriate as the generator's `pure`
+teacher. That does not make it a V2 initialization checkpoint.

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ testpaths = tests
 addopts = -ra
 markers =
     cuda_gate: optimized CUDA/CuPy coverage; optional unless ATOMIC_REQUIRE_CUDA_TESTS=1
+    v2_full_io: production-size AtomicNNUEV2 serializer/reader coverage

--- a/serialize_atomic_v2.py
+++ b/serialize_atomic_v2.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Explicit AtomicNNUEV2 checkpoint/network converter (never V1)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from atomic_v2.checkpoint import load_checkpoint, save_checkpoint
+from atomic_v2.serialization import read_nnue, write_nnue
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path)
+    parser.add_argument("target", type=Path)
+    parser.add_argument("--description", default="AtomicNNUEV2 explicit conversion")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.target.exists():
+        raise FileExistsError(f"refusing to overwrite target: {args.target}")
+    source_suffix = args.source.suffix.lower()
+    target_suffix = args.target.suffix.lower()
+    if source_suffix in (".pt", ".pth") and target_suffix == ".nnue":
+        model, _, _ = load_checkpoint(args.source)
+        temporary = args.target.with_name(args.target.name + ".tmp")
+        if temporary.exists():
+            raise FileExistsError(f"refusing to overwrite temporary target: {temporary}")
+        try:
+            with temporary.open("xb") as output:
+                write_nnue(output, model, args.description)
+            os.replace(temporary, args.target)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+    elif source_suffix == ".nnue" and target_suffix in (".pt", ".pth"):
+        with args.source.open("rb") as source:
+            model, _ = read_nnue(source)
+        save_checkpoint(args.target, model, step=0)
+    else:
+        raise ValueError("V2 conversion must be .pt/.pth -> .nnue or .nnue -> .pt/.pth")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_atomic_v2_backend_isolation.py
+++ b/tests/test_atomic_v2_backend_isolation.py
@@ -1,0 +1,46 @@
+import io
+import struct
+
+import pytest
+
+import serialize as legacy_serialize
+from atomic_v2.checkpoint import CheckpointError, validate_checkpoint_document
+from atomic_v2.contract import BACKEND_KEY, FILE_VERSION, NETWORK_HASH
+from atomic_v2.serialization import AtomicV2FormatError, read_header, write_header, write_nnue
+
+
+def test_v1_and_v2_readers_reject_the_other_backend_before_parameters():
+    legacy_header = struct.pack("<III", legacy_serialize.VERSION, 0, 0)
+    with pytest.raises(AtomicV2FormatError, match="version"):
+        read_header(io.BytesIO(legacy_header))
+
+    v2_header = io.BytesIO()
+    write_header(v2_header, "isolation")
+    with pytest.raises(legacy_serialize.NNUEFormatError, match="Unsupported NNUE version"):
+        legacy_serialize.NNUEReader(io.BytesIO(v2_header.getvalue()))
+
+
+def test_v2_writer_rejects_legacy_or_untyped_objects():
+    with pytest.raises(TypeError, match="only AtomicNNUEV2"):
+        write_nnue(io.BytesIO(), object())
+
+
+def test_checkpoint_backend_identity_is_mandatory_and_fail_closed():
+    valid = {
+        "backend": BACKEND_KEY,
+        "file_version": FILE_VERSION,
+        "network_hash": NETWORK_HASH,
+        "step": 1,
+        "model_state": {},
+    }
+    assert validate_checkpoint_document(valid) is valid
+
+    for field, value in (
+        ("backend", "legacy-atomic-v1"),
+        ("file_version", 0x7AF32F20),
+        ("network_hash", 0),
+    ):
+        invalid = dict(valid)
+        invalid[field] = value
+        with pytest.raises(CheckpointError, match=field):
+            validate_checkpoint_document(invalid)

--- a/tests/test_atomic_v2_contract.py
+++ b/tests/test_atomic_v2_contract.py
@@ -1,0 +1,76 @@
+import hashlib
+import json
+
+import pytest
+
+from atomic_v2.contract import (
+    ARCHITECTURE_HASH,
+    CONTRACT_SOURCE_BLOB,
+    CONTRACT_SOURCE_COMMIT,
+    CONTRACT_SOURCE_SHA256,
+    FEATURE_DIMENSIONS,
+    FEATURE_HASH,
+    FEATURE_TRANSFORMER_HASH,
+    FILE_VERSION,
+    NETWORK_HASH,
+    OFFICIAL_TRAINER_COMMIT,
+    ContractError,
+    contract_bytes,
+    load_contract,
+    validate_contract,
+)
+
+
+def test_vendored_contract_is_the_authenticated_engine_document():
+    raw = contract_bytes()
+
+    assert hashlib.sha256(raw).hexdigest() == CONTRACT_SOURCE_SHA256
+    assert CONTRACT_SOURCE_SHA256 == (
+        "70ea8da4cdd2f209fafc25f9419d3b3f226711b00701bf2fc02587dba65b82d7"
+    )
+    assert CONTRACT_SOURCE_COMMIT == "0818886d77328fe25850a3187e6460adaa980316"
+    assert CONTRACT_SOURCE_BLOB == "8a8003cbf5f7b97b50470de898ae16074aad7bca"
+    assert OFFICIAL_TRAINER_COMMIT == "b8512291deb4cd18afa67003bb6bc53dd522cbf0"
+    assert raw.endswith(b"\n")
+
+
+def test_atomic_v2_contract_freezes_identity_and_physical_topology():
+    document = load_contract()
+    backend = validate_contract(document)
+
+    assert FILE_VERSION == 0xA70C0002
+    assert FEATURE_HASH == 0x5F234CB8
+    assert FEATURE_TRANSFORMER_HASH == 0x5F2344B8
+    assert ARCHITECTURE_HASH == 0x63337116
+    assert NETWORK_HASH == 0x3C1035AE
+    assert FEATURE_DIMENSIONS == 45056
+    assert backend["feature_set"] == "HalfKAv2Atomic"
+    assert backend["accumulator_dimensions_per_perspective"] == 1024
+    assert backend["pairwise_multiply"] == {
+        "input_dimensions_per_perspective": 1024,
+        "half_dimensions": 512,
+        "output_dimensions_per_perspective": 512,
+        "concatenated_output_dimensions": 1024,
+    }
+    assert backend["topology"]["fc0"] == {
+        "input_dimensions": 1024,
+        "output_dimensions": 32,
+    }
+    assert backend["topology"]["fc1"] == {
+        "input_dimensions": 64,
+        "output_dimensions": 32,
+    }
+    assert backend["topology"]["fc2"] == {
+        "input_dimensions": 128,
+        "output_dimensions": 1,
+    }
+    assert backend["topology"]["fc0_skip_indices"] == [30, 31]
+    assert backend["topology"]["fc0_skip_coefficients"] == [1, -1]
+
+
+def test_contract_validation_is_fail_closed():
+    document = json.loads(contract_bytes())
+    document["backends"]["atomic-nnue-v2"]["network_hash"] = "0x00000000"
+
+    with pytest.raises(ContractError, match="network_hash"):
+        validate_contract(document)

--- a/tests/test_atomic_v2_dataset.py
+++ b/tests/test_atomic_v2_dataset.py
@@ -1,0 +1,163 @@
+import json
+
+import pytest
+import torch
+
+from atomic_v2.dataset import (
+    ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256,
+    ATOMIC_BIN_V2_SCHEMA_SHA256,
+    DatasetContractError,
+    create_provider,
+    validate_batch,
+    validate_loader_capabilities,
+    validate_train_validation_manifests,
+    validate_v2_manifest_entrypoint,
+)
+
+
+def loader_capabilities():
+    return {
+        "capability_version": 2,
+        "formats": {
+            "legacy-atomic-v1": {"read": True},
+            "atomic-bin-v2": {
+                "read": True,
+                "write": False,
+                "entrypoint": "manifest",
+                "header_size": 96,
+                "record_size": 64,
+                "schema_sha256": ATOMIC_BIN_V2_SCHEMA_SHA256,
+                "manifest_schema_sha256": ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256,
+            },
+        },
+    }
+
+
+def batch():
+    return (
+        torch.ones((2, 1)),
+        torch.zeros((2, 1)),
+        torch.tensor([[0, -1], [1, -1]], dtype=torch.int32),
+        torch.tensor([[1.0, 0.0], [1.0, 0.0]], dtype=torch.float32),
+        torch.tensor([[2, -1], [3, -1]], dtype=torch.int32),
+        torch.tensor([[1.0, 0.0], [1.0, 0.0]], dtype=torch.float32),
+        torch.tensor([[1.0], [0.0]]),
+        torch.tensor([[12.0], [-8.0]]),
+        torch.tensor([7, 7], dtype=torch.long),
+        torch.tensor([7, 7], dtype=torch.long),
+    )
+
+
+def write_v2_manifest(path):
+    path.write_text(
+        json.dumps(
+            {
+                "manifest_version": 1,
+                "manifest_schema_sha256": ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256,
+                "data_schema_sha256": ATOMIC_BIN_V2_SCHEMA_SHA256,
+                "format": "atomic-bin-v2",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_plural_native_handshake_is_required_for_atomic_bin_v2():
+    validate_loader_capabilities(loader_capabilities())
+
+    wrong = loader_capabilities()
+    wrong["formats"]["atomic-bin-v2"]["schema_sha256"] = "0" * 64
+    with pytest.raises(DatasetContractError, match="capability mismatch"):
+        validate_loader_capabilities(wrong)
+
+
+def test_existing_ten_tensor_loader_abi_is_validated():
+    values = batch()
+    assert validate_batch(values) == values
+
+    with pytest.raises(DatasetContractError, match="exactly 10"):
+        validate_batch(values[:-1])
+    wrong = list(values)
+    wrong[2] = wrong[2].to(torch.int64)
+    with pytest.raises(DatasetContractError, match="int32"):
+        validate_batch(tuple(wrong))
+    wrong = list(values)
+    wrong[7] = wrong[7].to(torch.float64)
+    with pytest.raises(DatasetContractError, match="float32"):
+        validate_batch(tuple(wrong))
+
+
+def test_v2_entrypoint_rejects_legacy_mixed_and_spoofed_manifests(tmp_path, monkeypatch):
+    training = write_v2_manifest(tmp_path / "train.atbin.manifest.json")
+    validation = write_v2_manifest(tmp_path / "validation.atbin.manifest.json")
+    legacy = tmp_path / "legacy.bin"
+    legacy.write_bytes(b"legacy")
+    spoofed = tmp_path / "spoofed.atbin.manifest.json"
+    spoofed.write_text(
+        '{"manifest_version":1,"manifest_schema_sha256":"'
+        + ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256
+        + '","data_schema_sha256":"'
+        + ATOMIC_BIN_V2_SCHEMA_SHA256
+        + '","format":"legacy-atomic-v1"}',
+        encoding="utf-8",
+    )
+
+    assert validate_v2_manifest_entrypoint(training) == training
+    with pytest.raises(DatasetContractError, match="entrypoint"):
+        validate_v2_manifest_entrypoint(legacy)
+    with pytest.raises(DatasetContractError, match="format mismatch"):
+        validate_v2_manifest_entrypoint(spoofed)
+
+    calls = []
+    fake_loader = type(
+        "FakeLoader",
+        (),
+        {
+            "atomic_training_data_schemas": staticmethod(loader_capabilities),
+            "validate_training_validation_data_paths": staticmethod(
+                lambda left, right: calls.append((left, right))
+            ),
+        },
+    )
+    monkeypatch.setitem(__import__("sys").modules, "nnue_dataset", fake_loader)
+    validate_train_validation_manifests(training, validation)
+    assert calls == [(str(training), str(validation))]
+
+    calls.clear()
+    with pytest.raises(DatasetContractError, match="entrypoint"):
+        validate_train_validation_manifests(training, legacy)
+    assert calls == []
+
+
+def test_provider_rejects_legacy_before_dual_format_native_loader(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy.bin"
+    legacy.write_bytes(b"legacy")
+    imported = []
+    monkeypatch.delitem(__import__("sys").modules, "nnue_dataset", raising=False)
+
+    original_import = __import__("builtins").__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "nnue_dataset":
+            imported.append(name)
+            raise AssertionError("native loader must not be imported")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+    with pytest.raises(DatasetContractError, match="entrypoint"):
+        create_provider(legacy, batch_size=1)
+    assert imported == []
+
+
+def test_provider_reads_an_authenticated_v2_manifest(atomic_v2_manifest):
+    provider = create_provider(
+        atomic_v2_manifest,
+        batch_size=1,
+        num_workers=1,
+        cyclic=False,
+    )
+
+    assert validate_batch(next(provider))[0].shape == (1, 1)
+    with pytest.raises(StopIteration):
+        next(provider)

--- a/tests/test_atomic_v2_model.py
+++ b/tests/test_atomic_v2_model.py
@@ -66,6 +66,49 @@ def test_sqr_clipped_relu_squares_signed_fc_preactivations(
     torch.testing.assert_close(output, torch.tensor([[0.25]]))
 
 
+@pytest.mark.parametrize(
+    "bucket_indices",
+    [torch.zeros(1, dtype=torch.long), torch.zeros((2, 1), dtype=torch.long)],
+)
+def test_layer_stacks_reject_bucket_shapes_that_can_broadcast(bucket_indices):
+    stacks = AtomicLayerStacks()
+
+    with pytest.raises(ValueError, match=r"shape \[batch\]"):
+        stacks(torch.zeros((2, 1024)), bucket_indices)
+
+
+@pytest.mark.parametrize(
+    "psqt_indices,layer_stack_indices",
+    [
+        (torch.zeros(1, dtype=torch.long), torch.zeros(2, dtype=torch.long)),
+        (torch.zeros((2, 1), dtype=torch.long), torch.zeros(2, dtype=torch.long)),
+        (torch.zeros(2, dtype=torch.long), torch.zeros(1, dtype=torch.long)),
+        (torch.zeros(2, dtype=torch.long), torch.zeros((2, 1), dtype=torch.long)),
+    ],
+)
+def test_model_rejects_bucket_shapes_that_can_broadcast(
+    psqt_indices, layer_stack_indices
+):
+    model = AtomicNNUEV2.__new__(AtomicNNUEV2)
+    torch.nn.Module.__init__(model)
+    us = torch.ones((2, 1), dtype=torch.float32)
+    them = 1.0 - us
+    indices = torch.full((2, 1), -1, dtype=torch.int32)
+    values = torch.zeros((2, 1), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match=r"shape \[batch\]"):
+        model(
+            us,
+            them,
+            indices,
+            values,
+            indices,
+            values,
+            psqt_indices,
+            layer_stack_indices,
+        )
+
+
 def test_pairwise_multiply_is_per_perspective_then_concatenated():
     x = torch.zeros((1, 2048), dtype=torch.float32)
     x[:, :512] = 2.0

--- a/tests/test_atomic_v2_model.py
+++ b/tests/test_atomic_v2_model.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 from atomic_v2.contract import FEATURE_DIMENSIONS, FEATURE_NAME
@@ -37,6 +38,32 @@ def test_sfnnv15_short_skip_is_fc0_minus_two_minus_minus_one():
     )
 
     torch.testing.assert_close(output, torch.full((3, 1), 2.0))
+
+
+@pytest.mark.parametrize(
+    "negative_layer,fc2_input",
+    [("fc0", 0), ("fc1", 64)],
+)
+def test_sqr_clipped_relu_squares_signed_fc_preactivations(
+    negative_layer, fc2_input
+):
+    stacks = AtomicLayerStacks()
+    with torch.no_grad():
+        for parameter in stacks.parameters():
+            parameter.zero_()
+        getattr(stacks, negative_layer).linear.bias[0] = -0.5
+        stacks.fc2.linear.weight[0, fc2_input] = 1.0
+
+    output = stacks(
+        torch.zeros((1, 1024), dtype=torch.float32),
+        torch.zeros(1, dtype=torch.long),
+        fake_quantize_activations=False,
+        fake_quantize_weights=False,
+    )
+
+    # Engine SqrClippedReLU and official nnue-pytorch both square first and
+    # clip second, so the squared branch receives (-0.5)^2 rather than zero.
+    torch.testing.assert_close(output, torch.tensor([[0.25]]))
 
 
 def test_pairwise_multiply_is_per_perspective_then_concatenated():

--- a/tests/test_atomic_v2_model.py
+++ b/tests/test_atomic_v2_model.py
@@ -1,0 +1,109 @@
+import torch
+
+from atomic_v2.contract import FEATURE_DIMENSIONS, FEATURE_NAME
+from atomic_v2.model import (
+    AtomicLayerStacks,
+    AtomicNNUEV2,
+    SparseFeatureTransformer,
+    pairwise_multiply,
+)
+
+
+def test_sfnnv15_layer_stack_has_the_physical_v2_shapes():
+    stacks = AtomicLayerStacks()
+
+    assert tuple(stacks.fc0.linear.weight.shape) == (8 * 32, 1024)
+    assert tuple(stacks.fc0.factorized_linear.weight.shape) == (32, 1024)
+    assert tuple(stacks.fc1.linear.weight.shape) == (8 * 32, 64)
+    assert tuple(stacks.fc2.linear.weight.shape) == (8, 128)
+
+
+def test_sfnnv15_short_skip_is_fc0_minus_two_minus_minus_one():
+    stacks = AtomicLayerStacks()
+    with torch.no_grad():
+        for parameter in stacks.parameters():
+            parameter.zero_()
+        for bucket in range(8):
+            offset = bucket * 32
+            stacks.fc0.linear.bias[offset + 30] = 3.0
+            stacks.fc0.linear.bias[offset + 31] = 1.0
+
+    output = stacks(
+        torch.zeros((3, 1024), dtype=torch.float32),
+        torch.tensor([0, 3, 7], dtype=torch.long),
+        fake_quantize_activations=False,
+        fake_quantize_weights=False,
+    )
+
+    torch.testing.assert_close(output, torch.full((3, 1), 2.0))
+
+
+def test_pairwise_multiply_is_per_perspective_then_concatenated():
+    x = torch.zeros((1, 2048), dtype=torch.float32)
+    x[:, :512] = 2.0
+    x[:, 512:1024] = 3.0
+    x[:, 1024:1536] = 5.0
+    x[:, 1536:] = 7.0
+
+    output = pairwise_multiply(x)
+
+    assert tuple(output.shape) == (1, 1024)
+    torch.testing.assert_close(output[:, :512], torch.full((1, 512), 6.0))
+    torch.testing.assert_close(output[:, 512:], torch.full((1, 512), 35.0))
+
+
+def test_hidden_weight_clipping_applies_to_coalesced_fc0_weights():
+    model = AtomicNNUEV2.__new__(AtomicNNUEV2)
+    torch.nn.Module.__init__(model)
+    model.network = AtomicLayerStacks()
+    with torch.no_grad():
+        model.network.fc0.factorized_linear.weight.fill_(0.75)
+        model.network.fc0.linear.weight.fill_(2.0)
+        model.network.fc1.linear.weight.fill_(-3.0)
+        model.network.fc2.linear.weight.fill_(3.0)
+
+    model.clip_weights()
+
+    merged, _ = model.network.fc0._merged_parameters()
+    assert float(merged.max()) <= 127.0 / 128.0
+    assert float(merged.min()) >= -127.0 / 128.0
+    assert float(model.network.fc1.linear.weight.min()) >= -127.0 / 64.0
+    assert float(model.network.fc2.linear.weight.max()) <= 127.0 / 128.0
+
+
+def test_production_model_exposes_only_halfkav2atomic(monkeypatch):
+    monkeypatch.setattr(AtomicNNUEV2, "_allocate_feature_parameters", lambda self: None)
+    model = AtomicNNUEV2.__new__(AtomicNNUEV2)
+
+    assert model.feature_name == FEATURE_NAME == "HalfKAv2Atomic"
+    assert model.num_features == FEATURE_DIMENSIONS == 45056
+    assert "Threat" not in model.feature_name
+
+
+def test_feature_transformer_quantizes_once_for_both_perspectives(monkeypatch):
+    transformer = SparseFeatureTransformer.__new__(SparseFeatureTransformer)
+    torch.nn.Module.__init__(transformer)
+    transformer.weight = torch.nn.Parameter(torch.zeros((2, 1032), dtype=torch.float32))
+    transformer.bias = torch.nn.Parameter(torch.zeros(1024, dtype=torch.float32))
+    calls = []
+    original = transformer._merged_parameters
+
+    def counted(fake_quantize_weights):
+        calls.append(fake_quantize_weights)
+        return original(fake_quantize_weights)
+
+    monkeypatch.setattr(transformer, "_merged_parameters", counted)
+    white_indices = torch.tensor([[0, -1]], dtype=torch.int32)
+    black_indices = torch.tensor([[1, -1]], dtype=torch.int32)
+    values = torch.tensor([[1.0, 0.0]], dtype=torch.float32)
+
+    white, black = transformer.forward_pair(
+        white_indices,
+        values,
+        black_indices,
+        values,
+        True,
+    )
+
+    assert calls == [True]
+    assert white.shape == black.shape == (1, 1032)

--- a/tests/test_atomic_v2_model.py
+++ b/tests/test_atomic_v2_model.py
@@ -7,6 +7,7 @@ from atomic_v2.model import (
     SparseFeatureTransformer,
     pairwise_multiply,
 )
+from atomic_v2.quantization import PSQT_WEIGHT_SCALE, fake_quantize_psqt_output
 
 
 def test_sfnnv15_layer_stack_has_the_physical_v2_shapes():
@@ -107,3 +108,34 @@ def test_feature_transformer_quantizes_once_for_both_perspectives(monkeypatch):
 
     assert calls == [True]
     assert white.shape == black.shape == (1, 1032)
+
+
+def test_psqt_signed_halves_truncate_toward_zero_with_ste_gradient():
+    raw_halves = torch.tensor(
+        [[0.5], [-0.5], [1.0], [-1.0]],
+        dtype=torch.float32,
+        requires_grad=True,
+    )
+
+    output = fake_quantize_psqt_output(raw_halves / PSQT_WEIGHT_SCALE)
+
+    torch.testing.assert_close(
+        output * PSQT_WEIGHT_SCALE,
+        torch.tensor([[0.0], [0.0], [1.0], [-1.0]]),
+    )
+    output.sum().backward()
+    torch.testing.assert_close(
+        raw_halves.grad,
+        torch.full_like(raw_halves, 1.0 / PSQT_WEIGHT_SCALE),
+    )
+
+
+def test_psqt_float32_rounding_matches_cpp_for_signed_delta_sweep():
+    delta = torch.arange(-10_000, 10_001, dtype=torch.int64)
+    soft_half = delta.to(torch.float32) / PSQT_WEIGHT_SCALE * 0.5
+
+    output = fake_quantize_psqt_output(soft_half)
+    actual = torch.round(output * PSQT_WEIGHT_SCALE).to(torch.int64)
+    expected = torch.div(delta, 2, rounding_mode="trunc")
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/test_atomic_v2_serialization.py
+++ b/tests/test_atomic_v2_serialization.py
@@ -153,6 +153,13 @@ class _HashingSink:
         return len(data)
 
 
+def _stream_sha256(source):
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
 FT_PAIR_BIASES = (
     (2, 32, 32),
     (15, 16, 32),
@@ -421,7 +428,7 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
             "Atomic-Stockfish AtomicNNUEV2 controlled synthetic CI source",
         )
     with path.open("rb") as source:
-        assert hashlib.file_digest(source, "sha256").hexdigest().upper() == (
+        assert _stream_sha256(source).upper() == (
             "4DEB05CFF79B5D5EBA51C560F64ED24224671C188B6C5DB27521033E587C87C6"
         )
     assert path.stat().st_size == 46_780_619

--- a/tests/test_atomic_v2_serialization.py
+++ b/tests/test_atomic_v2_serialization.py
@@ -37,6 +37,8 @@ from atomic_v2.serialization import (
     write_header,
     write_nnue,
     _encode_numpy_signed_leb128,
+    _quantized_numpy,
+    _write_compressed_tensor,
 )
 
 
@@ -68,6 +70,23 @@ def test_vectorized_writer_codec_matches_the_scalar_reference(dtype):
     write_compressed_array(stream, values)
     stream.seek(0)
     np.testing.assert_array_equal(read_compressed_array(stream, values.size, dtype), values)
+
+
+@pytest.mark.parametrize("dtype", [np.dtype("i1"), np.dtype("<i2"), np.dtype("<i4")])
+def test_quantized_writers_accept_the_full_signed_dtype_range(dtype):
+    limits = np.iinfo(dtype)
+    tensor = torch.tensor([limits.min, limits.max], dtype=torch.float64)
+
+    array = _quantized_numpy(tensor, 1.0, dtype, "boundary")
+    assert array.tolist() == [limits.min, limits.max]
+
+    stream = io.BytesIO()
+    _write_compressed_tensor(stream, tensor, 1.0, dtype, chunk_elements=1)
+    stream.seek(0)
+    assert read_compressed_array(stream, 2, dtype).tolist() == [
+        limits.min,
+        limits.max,
+    ]
 
 
 def test_streaming_compressed_reader_rejects_noncanonical_values():

--- a/tests/test_atomic_v2_serialization.py
+++ b/tests/test_atomic_v2_serialization.py
@@ -153,9 +153,65 @@ class _HashingSink:
         return len(data)
 
 
-def _reference_dense_trace():
-    transformed = (32 * 32) // 512
-    fc0 = (8192 + 5 * transformed + 7 * transformed, 4096 + 11 * transformed + 13 * transformed)
+FT_PAIR_BIASES = (
+    (2, 32, 32),
+    (15, 16, 32),
+    (16, 32, 48),
+    (31, 48, 48),
+    (32, 48, 56),
+    (63, 56, 56),
+    (64, 60, 60),
+    (255, 20, 32),
+    (256, 32, 40),
+    (511, 32, 56),
+)
+FT_PAIR_INDICES = tuple(index for index, _first, _second in FT_PAIR_BIASES)
+FC0_CONNECTIONS = (
+    (0, 2, 5),
+    (0, 514, 7),
+    (1, 2, 11),
+    (1, 514, 13),
+) + tuple(
+    connection
+    for ordinal, index in enumerate(FT_PAIR_INDICES[1:], start=1)
+    for connection in (
+        (0, index, 1 + ordinal % 5),
+        (0, 512 + index, 6 + ordinal % 5),
+        (1, index, 2 + ordinal % 4),
+        (1, 512 + index, 7 + ordinal % 4),
+    )
+)
+
+
+def _transformed_inputs():
+    values = {}
+    for index, first, second in FT_PAIR_BIASES:
+        transformed = first * second // 512
+        values[index] = transformed
+        values[512 + index] = transformed
+    return values
+
+
+def _reference_dense_trace(bucket=7):
+    inputs = _transformed_inputs()
+    transformed = tuple(inputs[index] for index in FT_PAIR_INDICES)
+    fc0_biases = []
+    for output, target in enumerate((8216, 4144)):
+        contribution = sum(
+            value * inputs[input_index]
+            for candidate, input_index, value in FC0_CONNECTIONS
+            if candidate == output
+        )
+        fc0_biases.append(target - contribution)
+    fc0 = tuple(
+        fc0_biases[output]
+        + sum(
+            value * inputs[input_index]
+            for candidate, input_index, value in FC0_CONNECTIONS
+            if candidate == output
+        )
+        for output in range(2)
+    )
     sqr0 = tuple(value * value >> 21 for value in fc0)
     crelu0 = tuple(value >> 7 for value in fc0)
     fc1 = (
@@ -166,6 +222,7 @@ def _reference_dense_trace():
     crelu1 = tuple(value >> 6 for value in fc1)
     fc2 = (
         1024
+        + 128 * (bucket - 7)
         + sqr0[0]
         + 2 * sqr0[1]
         + 3 * crelu0[0]
@@ -205,8 +262,9 @@ def _controlled_wire_model():
     ).remainder(127) - 63
     weight[:, 1024:1031] = psqt.to(torch.float32) / PSQT_WEIGHT_SCALE
     bias = torch.zeros(1024, dtype=torch.float32)
-    bias[2] = 32.0 / FT_ONE
-    bias[514] = 32.0 / FT_ONE
+    for index, first, second in FT_PAIR_BIASES:
+        bias[index] = first / FT_ONE
+        bias[512 + index] = second / FT_ONE
     object.__setattr__(
         model,
         "feature_transformer",
@@ -221,15 +279,10 @@ def _controlled_wire_model():
             parameter.zero_()
         for bucket in range(8):
             fc0_row = bucket * 32
-            model.network.fc0.linear.bias[fc0_row] = 8192.0 / FC0_BIAS_SCALE
-            model.network.fc0.linear.bias[fc0_row + 1] = 4096.0 / FC0_BIAS_SCALE
+            model.network.fc0.linear.bias[fc0_row] = 7836.0 / FC0_BIAS_SCALE
+            model.network.fc0.linear.bias[fc0_row + 1] = 3718.0 / FC0_BIAS_SCALE
             model.network.fc0.linear.bias[fc0_row + 30] = 16384.0 / FC0_BIAS_SCALE
-            for output, input_index, value in (
-                (0, 2, 5),
-                (0, 514, 7),
-                (1, 2, 11),
-                (1, 514, 13),
-            ):
+            for output, input_index, value in FC0_CONNECTIONS:
                 model.network.fc0.linear.weight[fc0_row + output, input_index] = (
                     value / FC0_WEIGHT_SCALE
                 )
@@ -251,7 +304,9 @@ def _controlled_wire_model():
                     value / FC1_WEIGHT_SCALE
                 )
 
-            model.network.fc2.linear.bias[bucket] = 1024.0 / FC2_BIAS_SCALE
+            model.network.fc2.linear.bias[bucket] = (
+                1024.0 + 128.0 * (bucket - 7)
+            ) / FC2_BIAS_SCALE
             for input_index, value in (
                 (0, 1),
                 (1, 2),
@@ -269,7 +324,7 @@ def _controlled_wire_model():
 
 
 @torch.no_grad()
-def _model_dense_trace(model, indices, values):
+def _model_dense_trace(model, indices, values, bucket_index=7):
     white, black = model.feature_transformer.forward_pair(
         indices,
         values,
@@ -283,7 +338,7 @@ def _model_dense_trace(model, indices, values):
     transformed = fake_quantize_activation(
         pairwise_multiply(clip_feature_activation(side_ordered))
     )
-    bucket = torch.tensor([7], dtype=torch.long)
+    bucket = torch.tensor([bucket_index], dtype=torch.long)
 
     fc0 = model.network.fc0(transformed, bucket, True)
     activated0 = clip_hidden_activation(
@@ -313,7 +368,10 @@ def _model_dense_trace(model, indices, values):
         return tuple(int(round(float(value) * scale)) for value in tensor.reshape(-1))
 
     return {
-        "transformed": raw(transformed[:, 2], HIDDEN_ONE)[0],
+        "transformed": tuple(
+            raw(transformed[:, index], HIDDEN_ONE)[0]
+            for index in FT_PAIR_INDICES
+        ),
         "fc0": raw(fc0[:, :2], FC0_BIAS_SCALE),
         "sqr0": raw(activated0[:, :2], HIDDEN_ONE),
         "crelu0": raw(activated0[:, 32:34], HIDDEN_ONE),
@@ -364,7 +422,7 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
         )
     with path.open("rb") as source:
         assert hashlib.file_digest(source, "sha256").hexdigest().upper() == (
-            "A14261B40D638B98257241C17DCC52DFCB5023B44F91D21C742F398183A4EA64"
+            "4DEB05CFF79B5D5EBA51C560F64ED24224671C188B6C5DB27521033E587C87C6"
         )
     assert path.stat().st_size == 46_780_619
     del source_model
@@ -373,9 +431,10 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
     with path.open("rb") as source:
         model, description = read_nnue(source)
     assert description == "Atomic-Stockfish AtomicNNUEV2 controlled synthetic CI source"
-    assert torch.count_nonzero(model.feature_transformer.bias) == 2
-    assert model.feature_transformer.bias[2] * FT_ONE == 32
-    assert model.feature_transformer.bias[514] * FT_ONE == 32
+    assert torch.count_nonzero(model.feature_transformer.bias) == 20
+    for index, first, second in FT_PAIR_BIASES:
+        assert model.feature_transformer.bias[index] * FT_ONE == first
+        assert model.feature_transformer.bias[512 + index] * FT_ONE == second
     expected_psqt = torch.tensor(
         [
             [-63, -46, -29, -12, 5, 22, 39, 0],
@@ -394,7 +453,7 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
     indices = torch.tensor([[0, -1]], dtype=torch.int32)
     values = torch.tensor([[1.0, 0.0]], dtype=torch.float32)
     expected_trace = {
-        "transformed": 2,
+        "transformed": (2, 1, 3, 4, 5, 6, 7, 1, 2, 3),
         "fc0": (8216, 4144),
         "sqr0": (32, 8),
         "crelu0": (64, 32),
@@ -405,21 +464,48 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
         "fwd": 18965,
         "raw": 11112,
     }
-    assert _reference_dense_trace() == expected_trace
-    assert _model_dense_trace(model, indices, values) == expected_trace
+    traces = tuple(_reference_dense_trace(bucket) for bucket in range(8))
+    assert traces[-1] == expected_trace
+    assert _model_dense_trace(model, indices, values, 7) == expected_trace
+    assert tuple(trace["raw"] for trace in traces) == (
+        10587,
+        10662,
+        10737,
+        10812,
+        10887,
+        10962,
+        11037,
+        11112,
+    )
     with torch.no_grad():
         output = model(
-            us,
-            1.0 - us,
-            indices,
-            values,
-            indices,
-            values,
-            torch.tensor([7], dtype=torch.long),
-            torch.tensor([7], dtype=torch.long),
+            us.repeat(8, 1),
+            (1.0 - us).repeat(8, 1),
+            indices.repeat(8, 1),
+            values.repeat(8, 1),
+            indices.repeat(8, 1),
+            values.repeat(8, 1),
+            torch.full((8,), 7, dtype=torch.long),
+            torch.arange(8, dtype=torch.long),
         )
-    torch.testing.assert_close(output, torch.tensor([[11112.0 / PSQT_WEIGHT_SCALE]]))
-    assert int(round(output.item() * PSQT_WEIGHT_SCALE)) // 16 == 694
+    raw_by_bucket = torch.tensor(
+        [10587, 10662, 10737, 10812, 10887, 10962, 11037, 11112],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(
+        output,
+        (raw_by_bucket / PSQT_WEIGHT_SCALE).reshape(-1, 1),
+    )
+    assert tuple((raw_by_bucket.to(torch.int64) // 16).tolist()) == (
+        661,
+        666,
+        671,
+        675,
+        680,
+        685,
+        689,
+        694,
+    )
 
     with torch.no_grad():
         diagnostic_output = model(
@@ -440,7 +526,7 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
     reexport = _HashingSink()
     write_nnue(reexport, model, description)
     assert reexport.digest.hexdigest().upper() == (
-        "A14261B40D638B98257241C17DCC52DFCB5023B44F91D21C742F398183A4EA64"
+        "4DEB05CFF79B5D5EBA51C560F64ED24224671C188B6C5DB27521033E587C87C6"
     )
     del model
     gc.collect()

--- a/tests/test_atomic_v2_serialization.py
+++ b/tests/test_atomic_v2_serialization.py
@@ -9,7 +9,22 @@ import pytest
 import torch
 
 from atomic_v2.contract import FILE_VERSION, NETWORK_HASH
-from atomic_v2.model import AtomicLayerStacks, AtomicNNUEV2
+from atomic_v2.model import AtomicLayerStacks, AtomicNNUEV2, pairwise_multiply
+from atomic_v2.quantization import (
+    FC0_BIAS_SCALE,
+    FC0_WEIGHT_SCALE,
+    FC1_BIAS_SCALE,
+    FC1_WEIGHT_SCALE,
+    FC2_BIAS_SCALE,
+    FC2_WEIGHT_SCALE,
+    FT_ONE,
+    HIDDEN_ONE,
+    PSQT_WEIGHT_SCALE,
+    clip_feature_activation,
+    clip_hidden_activation,
+    fake_quantize_activation,
+    fake_quantize_output,
+)
 from atomic_v2.serialization import (
     LEB128_MAGIC,
     AtomicV2FormatError,
@@ -138,6 +153,43 @@ class _HashingSink:
         return len(data)
 
 
+def _reference_dense_trace():
+    transformed = (32 * 32) // 512
+    fc0 = (8192 + 5 * transformed + 7 * transformed, 4096 + 11 * transformed + 13 * transformed)
+    sqr0 = tuple(value * value >> 21 for value in fc0)
+    crelu0 = tuple(value >> 7 for value in fc0)
+    fc1 = (
+        4096 + 2 * sqr0[0] + 3 * sqr0[1] + 4 * crelu0[0] + 5 * crelu0[1],
+        2048 + 6 * sqr0[0] + 7 * sqr0[1] + 8 * crelu0[0] + 9 * crelu0[1],
+    )
+    sqr1 = tuple(value * value >> 19 for value in fc1)
+    crelu1 = tuple(value >> 6 for value in fc1)
+    fc2 = (
+        1024
+        + sqr0[0]
+        + 2 * sqr0[1]
+        + 3 * crelu0[0]
+        + 4 * crelu0[1]
+        + 5 * sqr1[0]
+        + 6 * sqr1[1]
+        + 7 * crelu1[0]
+        + 8 * crelu1[1]
+    )
+    fwd = fc2 + 16384
+    return {
+        "transformed": transformed,
+        "fc0": fc0,
+        "sqr0": sqr0,
+        "crelu0": crelu0,
+        "fc1": fc1,
+        "sqr1": sqr1,
+        "crelu1": crelu1,
+        "fc2": fc2,
+        "fwd": fwd,
+        "raw": fwd * int(PSQT_WEIGHT_SCALE) // int(FC2_BIAS_SCALE),
+    }
+
+
 def _controlled_wire_model():
     # This identity is pinned by Atomic-Stockfish's independent
     # tests/create_synthetic_atomic_v2_nnue.py writer.
@@ -147,12 +199,20 @@ def _controlled_wire_model():
     feature = torch.arange(45056, dtype=torch.int64)
     weight[:, 0] = (feature.remainder(63) + 1).to(torch.float32) / 256.0
     weight[:, 1] = -((feature * 17).remainder(64) + 1).to(torch.float32) / 256.0
+    buckets = torch.arange(7, dtype=torch.int64)
+    psqt = (
+        feature.reshape(-1, 1) * (2 * buckets + 1) + 17 * buckets
+    ).remainder(127) - 63
+    weight[:, 1024:1031] = psqt.to(torch.float32) / PSQT_WEIGHT_SCALE
+    bias = torch.zeros(1024, dtype=torch.float32)
+    bias[2] = 32.0 / FT_ONE
+    bias[514] = 32.0 / FT_ONE
     object.__setattr__(
         model,
         "feature_transformer",
         SimpleNamespace(
             weight=weight,
-            bias=torch.zeros(1024, dtype=torch.float32),
+            bias=bias,
         ),
     )
     model.network = AtomicLayerStacks()
@@ -160,8 +220,110 @@ def _controlled_wire_model():
         for parameter in model.network.parameters():
             parameter.zero_()
         for bucket in range(8):
-            model.network.fc0.linear.bias[bucket * 32 + 30] = 1.0
+            fc0_row = bucket * 32
+            model.network.fc0.linear.bias[fc0_row] = 8192.0 / FC0_BIAS_SCALE
+            model.network.fc0.linear.bias[fc0_row + 1] = 4096.0 / FC0_BIAS_SCALE
+            model.network.fc0.linear.bias[fc0_row + 30] = 16384.0 / FC0_BIAS_SCALE
+            for output, input_index, value in (
+                (0, 2, 5),
+                (0, 514, 7),
+                (1, 2, 11),
+                (1, 514, 13),
+            ):
+                model.network.fc0.linear.weight[fc0_row + output, input_index] = (
+                    value / FC0_WEIGHT_SCALE
+                )
+
+            fc1_row = bucket * 32
+            model.network.fc1.linear.bias[fc1_row] = 4096.0 / FC1_BIAS_SCALE
+            model.network.fc1.linear.bias[fc1_row + 1] = 2048.0 / FC1_BIAS_SCALE
+            for output, input_index, value in (
+                (0, 0, 2),
+                (0, 1, 3),
+                (0, 32, 4),
+                (0, 33, 5),
+                (1, 0, 6),
+                (1, 1, 7),
+                (1, 32, 8),
+                (1, 33, 9),
+            ):
+                model.network.fc1.linear.weight[fc1_row + output, input_index] = (
+                    value / FC1_WEIGHT_SCALE
+                )
+
+            model.network.fc2.linear.bias[bucket] = 1024.0 / FC2_BIAS_SCALE
+            for input_index, value in (
+                (0, 1),
+                (1, 2),
+                (32, 3),
+                (33, 4),
+                (64, 5),
+                (65, 6),
+                (96, 7),
+                (97, 8),
+            ):
+                model.network.fc2.linear.weight[bucket, input_index] = (
+                    value / FC2_WEIGHT_SCALE
+                )
     return model
+
+
+@torch.no_grad()
+def _model_dense_trace(model, indices, values):
+    white, black = model.feature_transformer.forward_pair(
+        indices,
+        values,
+        indices,
+        values,
+        True,
+    )
+    white_main = white[:, :1024]
+    black_main = black[:, :1024]
+    side_ordered = torch.cat((white_main, black_main), dim=1)
+    transformed = fake_quantize_activation(
+        pairwise_multiply(clip_feature_activation(side_ordered))
+    )
+    bucket = torch.tensor([7], dtype=torch.long)
+
+    fc0 = model.network.fc0(transformed, bucket, True)
+    activated0 = clip_hidden_activation(
+        torch.cat(
+            (
+                fake_quantize_activation(fc0.square()),
+                fake_quantize_activation(fc0),
+            ),
+            dim=1,
+        )
+    )
+    fc1 = model.network.fc1(activated0, bucket, True)
+    activated1 = clip_hidden_activation(
+        torch.cat(
+            (
+                fake_quantize_activation(fc1.square()),
+                fake_quantize_activation(fc1),
+            ),
+            dim=1,
+        )
+    )
+    fc2 = model.network.fc2(torch.cat((activated0, activated1), dim=1), bucket, True)
+    fwd = fc2 + fc0[:, -2:-1] - fc0[:, -1:]
+    output = fake_quantize_output(fwd)
+
+    def raw(tensor, scale):
+        return tuple(int(round(float(value) * scale)) for value in tensor.reshape(-1))
+
+    return {
+        "transformed": raw(transformed[:, 2], HIDDEN_ONE)[0],
+        "fc0": raw(fc0[:, :2], FC0_BIAS_SCALE),
+        "sqr0": raw(activated0[:, :2], HIDDEN_ONE),
+        "crelu0": raw(activated0[:, 32:34], HIDDEN_ONE),
+        "fc1": raw(fc1[:, :2], FC1_BIAS_SCALE),
+        "sqr1": raw(activated1[:, :2], HIDDEN_ONE),
+        "crelu1": raw(activated1[:, 32:34], HIDDEN_ONE),
+        "fc2": raw(fc2, FC2_BIAS_SCALE)[0],
+        "fwd": raw(fwd, FC2_BIAS_SCALE)[0],
+        "raw": raw(output, PSQT_WEIGHT_SCALE)[0],
+    }
 
 
 def _zero_stride_wire_model():
@@ -202,18 +364,49 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
         )
     with path.open("rb") as source:
         assert hashlib.file_digest(source, "sha256").hexdigest().upper() == (
-            "2AF647392F7A30072C2DB29837C9175D22BA2DF450931762D0E2DE8CFE337B50"
+            "A14261B40D638B98257241C17DCC52DFCB5023B44F91D21C742F398183A4EA64"
         )
+    assert path.stat().st_size == 46_780_619
     del source_model
     gc.collect()
 
     with path.open("rb") as source:
         model, description = read_nnue(source)
     assert description == "Atomic-Stockfish AtomicNNUEV2 controlled synthetic CI source"
+    assert torch.count_nonzero(model.feature_transformer.bias) == 2
+    assert model.feature_transformer.bias[2] * FT_ONE == 32
+    assert model.feature_transformer.bias[514] * FT_ONE == 32
+    expected_psqt = torch.tensor(
+        [
+            [-63, -46, -29, -12, 5, 22, 39, 0],
+            [-62, -43, -24, -5, 14, 33, 52, 0],
+        ],
+        dtype=torch.float32,
+    ) / PSQT_WEIGHT_SCALE
+    torch.testing.assert_close(
+        model.feature_transformer.weight[:2, 1024:],
+        expected_psqt,
+    )
+    assert torch.count_nonzero(model.feature_transformer.weight[:, 1024:1031]) > 0
+    assert torch.count_nonzero(model.feature_transformer.weight[:, 1031]) == 0
 
     us = torch.tensor([[1.0]], dtype=torch.float32)
     indices = torch.tensor([[0, -1]], dtype=torch.int32)
     values = torch.tensor([[1.0, 0.0]], dtype=torch.float32)
+    expected_trace = {
+        "transformed": 2,
+        "fc0": (8216, 4144),
+        "sqr0": (32, 8),
+        "crelu0": (64, 32),
+        "fc1": (4600, 3096),
+        "sqr1": (40, 18),
+        "crelu1": (71, 48),
+        "fc2": 2581,
+        "fwd": 18965,
+        "raw": 11112,
+    }
+    assert _reference_dense_trace() == expected_trace
+    assert _model_dense_trace(model, indices, values) == expected_trace
     with torch.no_grad():
         output = model(
             us,
@@ -225,12 +418,29 @@ def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path)
             torch.tensor([7], dtype=torch.long),
             torch.tensor([7], dtype=torch.long),
         )
-    torch.testing.assert_close(output, torch.ones((1, 1)))
+    torch.testing.assert_close(output, torch.tensor([[11112.0 / PSQT_WEIGHT_SCALE]]))
+    assert int(round(output.item() * PSQT_WEIGHT_SCALE)) // 16 == 694
+
+    with torch.no_grad():
+        diagnostic_output = model(
+            us,
+            1.0 - us,
+            torch.tensor([[0, -1]], dtype=torch.int32),
+            values,
+            torch.tensor([[1, -1]], dtype=torch.int32),
+            values,
+            torch.tensor([0], dtype=torch.long),
+            torch.tensor([7], dtype=torch.long),
+        )
+    torch.testing.assert_close(
+        diagnostic_output,
+        torch.tensor([[11112.0 / PSQT_WEIGHT_SCALE]]),
+    )
 
     reexport = _HashingSink()
     write_nnue(reexport, model, description)
     assert reexport.digest.hexdigest().upper() == (
-        "2AF647392F7A30072C2DB29837C9175D22BA2DF450931762D0E2DE8CFE337B50"
+        "A14261B40D638B98257241C17DCC52DFCB5023B44F91D21C742F398183A4EA64"
     )
     del model
     gc.collect()

--- a/tests/test_atomic_v2_serialization.py
+++ b/tests/test_atomic_v2_serialization.py
@@ -1,0 +1,236 @@
+import io
+import gc
+import hashlib
+import struct
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from atomic_v2.contract import FILE_VERSION, NETWORK_HASH
+from atomic_v2.model import AtomicLayerStacks, AtomicNNUEV2
+from atomic_v2.serialization import (
+    LEB128_MAGIC,
+    AtomicV2FormatError,
+    decode_signed_leb128,
+    encode_signed_leb128,
+    read_compressed_array,
+    read_header,
+    read_nnue,
+    write_compressed_array,
+    write_header,
+    write_nnue,
+    _encode_numpy_signed_leb128,
+)
+
+
+@pytest.mark.parametrize(
+    "dtype,values",
+    [
+        (np.dtype("<i2"), [-32768, -8193, -65, -64, -1, 0, 63, 64, 8192, 32767]),
+        (np.dtype("<i4"), [-(2**31), -(2**20), -1, 0, 1, 2**20, 2**31 - 1]),
+    ],
+)
+def test_signed_leb128_round_trip_is_canonical(dtype, values):
+    encoded = encode_signed_leb128(values, dtype)
+    decoded = decode_signed_leb128(encoded, len(values), dtype)
+
+    assert decoded.dtype == dtype
+    assert decoded.tolist() == values
+    assert encode_signed_leb128(decoded, dtype) == encoded
+
+
+@pytest.mark.parametrize("dtype", [np.dtype("<i2"), np.dtype("<i4")])
+def test_vectorized_writer_codec_matches_the_scalar_reference(dtype):
+    generator = np.random.default_rng(20260714)
+    limits = np.iinfo(dtype)
+    values = generator.integers(limits.min, limits.max, size=4096, dtype=dtype)
+
+    assert _encode_numpy_signed_leb128(values) == encode_signed_leb128(values, dtype)
+
+    stream = io.BytesIO()
+    write_compressed_array(stream, values)
+    stream.seek(0)
+    np.testing.assert_array_equal(read_compressed_array(stream, values.size, dtype), values)
+
+
+def test_streaming_compressed_reader_rejects_noncanonical_values():
+    payload = b"\x80\x00"
+    stream = io.BytesIO(LEB128_MAGIC + struct.pack("<I", len(payload)) + payload)
+    with pytest.raises(AtomicV2FormatError, match="non-canonical"):
+        read_compressed_array(stream, 1, np.dtype("<i2"))
+
+
+@pytest.mark.parametrize(
+    "payload,error",
+    [
+        (b"", "truncated"),
+        (b"\x80", "truncated"),
+        (b"\x80\x00", "non-canonical"),
+        (b"\xff\xff\xff\xff\x7f", "out of range"),
+        (b"\x00\x00", "trailing"),
+    ],
+)
+def test_signed_leb128_rejects_malformed_payloads(payload, error):
+    with pytest.raises(AtomicV2FormatError, match=error):
+        decode_signed_leb128(payload, 1, np.dtype("<i2"))
+
+
+def test_compressed_array_has_strict_magic_length_and_value_count():
+    stream = io.BytesIO()
+    values = np.asarray([-2, 0, 127], dtype="<i2")
+    write_compressed_array(stream, values)
+    payload = stream.getvalue()
+
+    assert payload.startswith(LEB128_MAGIC)
+    assert read_compressed_array(io.BytesIO(payload), 3, np.dtype("<i2")).tolist() == [-2, 0, 127]
+
+    with pytest.raises(AtomicV2FormatError, match="magic"):
+        read_compressed_array(io.BytesIO(b"X" + payload[1:]), 3, np.dtype("<i2"))
+    with pytest.raises(AtomicV2FormatError, match="payload"):
+        read_compressed_array(io.BytesIO(payload[:-1]), 3, np.dtype("<i2"))
+    # The encoded byte length can still be legal for four values (the final
+    # value above needs two bytes), so the strict decoder may only discover
+    # the count mismatch when it reaches the end of the payload.
+    with pytest.raises(AtomicV2FormatError, match="length|truncated"):
+        read_compressed_array(io.BytesIO(payload), 4, np.dtype("<i2"))
+
+
+def test_v2_header_round_trip_and_v1_rejection_happen_before_parameters():
+    stream = io.BytesIO()
+    write_header(stream, "atomic-v2-test")
+    stream.seek(0)
+
+    assert read_header(stream) == "atomic-v2-test"
+
+    legacy = io.BytesIO(struct.pack("<II", 0x7AF32F20, NETWORK_HASH) + struct.pack("<I", 0))
+    with pytest.raises(AtomicV2FormatError, match="version"):
+        read_header(legacy)
+
+    wrong_hash = io.BytesIO(struct.pack("<III", FILE_VERSION, 0, 0))
+    with pytest.raises(AtomicV2FormatError, match="network hash"):
+        read_header(wrong_hash)
+
+
+def test_v2_header_rejects_oversized_invalid_utf8_and_truncation():
+    oversized = io.BytesIO(struct.pack("<III", FILE_VERSION, NETWORK_HASH, (1 << 20) + 1))
+    with pytest.raises(AtomicV2FormatError, match="description length"):
+        read_header(oversized)
+
+    invalid_utf8 = io.BytesIO(struct.pack("<III", FILE_VERSION, NETWORK_HASH, 1) + b"\xff")
+    with pytest.raises(AtomicV2FormatError, match="UTF-8"):
+        read_header(invalid_utf8)
+
+    truncated = io.BytesIO(struct.pack("<III", FILE_VERSION, NETWORK_HASH, 3) + b"ab")
+    with pytest.raises(AtomicV2FormatError, match="description"):
+        read_header(truncated)
+
+
+class _HashingSink:
+    def __init__(self):
+        self.digest = hashlib.sha256()
+        self.size = 0
+
+    def write(self, data):
+        self.digest.update(data)
+        self.size += len(data)
+        return len(data)
+
+
+def _controlled_wire_model():
+    # This identity is pinned by Atomic-Stockfish's independent
+    # tests/create_synthetic_atomic_v2_nnue.py writer.
+    model = AtomicNNUEV2.__new__(AtomicNNUEV2)
+    torch.nn.Module.__init__(model)
+    weight = torch.zeros((45056, 1032), dtype=torch.float32)
+    feature = torch.arange(45056, dtype=torch.int64)
+    weight[:, 0] = (feature.remainder(63) + 1).to(torch.float32) / 256.0
+    weight[:, 1] = -((feature * 17).remainder(64) + 1).to(torch.float32) / 256.0
+    object.__setattr__(
+        model,
+        "feature_transformer",
+        SimpleNamespace(
+            weight=weight,
+            bias=torch.zeros(1024, dtype=torch.float32),
+        ),
+    )
+    model.network = AtomicLayerStacks()
+    with torch.no_grad():
+        for parameter in model.network.parameters():
+            parameter.zero_()
+        for bucket in range(8):
+            model.network.fc0.linear.bias[bucket * 32 + 30] = 1.0
+    return model
+
+
+def _zero_stride_wire_model():
+    model = AtomicNNUEV2.__new__(AtomicNNUEV2)
+    torch.nn.Module.__init__(model)
+    object.__setattr__(
+        model,
+        "feature_transformer",
+        SimpleNamespace(
+            weight=torch.zeros(1, dtype=torch.float32).expand(45056, 1032),
+            bias=torch.zeros(1024, dtype=torch.float32),
+        ),
+    )
+    model.network = AtomicLayerStacks()
+    return model
+
+
+def test_writer_validates_every_contract_shape_before_header_bytes():
+    model = _zero_stride_wire_model()
+    model.network.fc1.linear.weight = torch.nn.Parameter(torch.zeros((255, 64)))
+    output = io.BytesIO()
+
+    with pytest.raises(AtomicV2FormatError, match="fc1 weight shape"):
+        write_nnue(output, model)
+
+    assert output.getvalue() == b""
+
+
+@pytest.mark.v2_full_io
+def test_reader_imports_and_evaluates_the_engine_controlled_v2_fixture(tmp_path):
+    path = tmp_path / "engine-controlled-v2.nnue"
+    source_model = _controlled_wire_model()
+    with path.open("xb") as output:
+        write_nnue(
+            output,
+            source_model,
+            "Atomic-Stockfish AtomicNNUEV2 controlled synthetic CI source",
+        )
+    with path.open("rb") as source:
+        assert hashlib.file_digest(source, "sha256").hexdigest().upper() == (
+            "2AF647392F7A30072C2DB29837C9175D22BA2DF450931762D0E2DE8CFE337B50"
+        )
+    del source_model
+    gc.collect()
+
+    with path.open("rb") as source:
+        model, description = read_nnue(source)
+    assert description == "Atomic-Stockfish AtomicNNUEV2 controlled synthetic CI source"
+
+    us = torch.tensor([[1.0]], dtype=torch.float32)
+    indices = torch.tensor([[0, -1]], dtype=torch.int32)
+    values = torch.tensor([[1.0, 0.0]], dtype=torch.float32)
+    with torch.no_grad():
+        output = model(
+            us,
+            1.0 - us,
+            indices,
+            values,
+            indices,
+            values,
+            torch.tensor([7], dtype=torch.long),
+            torch.tensor([7], dtype=torch.long),
+        )
+    torch.testing.assert_close(output, torch.ones((1, 1)))
+
+    reexport = _HashingSink()
+    write_nnue(reexport, model, description)
+    assert reexport.digest.hexdigest().upper() == (
+        "2AF647392F7A30072C2DB29837C9175D22BA2DF450931762D0E2DE8CFE337B50"
+    )
+    del model
+    gc.collect()

--- a/tests/test_atomic_v2_training.py
+++ b/tests/test_atomic_v2_training.py
@@ -1,0 +1,60 @@
+import gc
+
+import pytest
+import torch
+
+from atomic_v2.training import deterministic_cpu_one_step
+from train_atomic_v2 import _validation_loss, default_batch_size
+
+
+def test_production_shape_cpu_step_is_deterministic():
+    first = deterministic_cpu_one_step(seed=20260714)
+    gc.collect()
+    second = deterministic_cpu_one_step(seed=20260714)
+
+    assert first == second
+    assert first.loss_before > 0
+    assert first.loss_after <= first.loss_before
+    assert len(first.parameter_sha256) == 64
+
+
+class ConstantValidationModel(torch.nn.Module):
+    def forward(self, *inputs):
+        return torch.zeros((inputs[0].shape[0], 1), dtype=torch.float32)
+
+
+def validation_batch(outcomes):
+    size = len(outcomes)
+    indices = torch.full((size, 1), -1, dtype=torch.int32)
+    values = torch.zeros((size, 1), dtype=torch.float32)
+    us = torch.ones((size, 1), dtype=torch.float32)
+    return (
+        us,
+        1.0 - us,
+        indices,
+        values,
+        indices.clone(),
+        values.clone(),
+        torch.tensor(outcomes, dtype=torch.float32).reshape(-1, 1),
+        torch.zeros((size, 1), dtype=torch.float32),
+        torch.zeros(size, dtype=torch.long),
+        torch.zeros(size, dtype=torch.long),
+    )
+
+
+def test_validation_is_sample_weighted_and_honors_persisted_budget():
+    model = ConstantValidationModel()
+    batches = [validation_batch([0.0]), validation_batch([0.5, 0.5, 1.0])]
+
+    loss, samples = _validation_loss(model, batches, 0.0, max_samples=3)
+
+    # sigmoid(0) is 0.5: first sample has squared loss .25 and the next
+    # two have zero loss. The fourth sample is outside the explicit budget.
+    assert samples == 3
+    assert loss == pytest.approx(0.25 / 3.0)
+    assert model.training
+
+
+def test_batch_size_default_is_cpu_appropriate():
+    assert default_batch_size("cpu") == 128
+    assert default_batch_size("cuda") == 16_384

--- a/tests/test_trainer_ci_contract.py
+++ b/tests/test_trainer_ci_contract.py
@@ -15,3 +15,9 @@ def test_ci_fetches_complete_audited_engine_main_history():
 
     # Both CPU and trusted CUDA jobs must make the ancestry proof meaningful.
     assert workflow.count(command) == 2
+
+
+def test_authenticated_contract_bytes_are_lf_on_every_checkout():
+    attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8").splitlines()
+
+    assert "atomic_v2/schema/*.json text eol=lf" in attributes

--- a/tests/test_trainer_ci_contract.py
+++ b/tests/test_trainer_ci_contract.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ci_fetches_complete_audited_engine_main_history():
+    workflow = (ROOT / ".github" / "workflows" / "trainer-tests.yml").read_text(
+        encoding="utf-8"
+    )
+    command = (
+        "git -C external/Atomic-Stockfish fetch --no-tags --depth=2147483647 "
+        "origin +refs/heads/main:refs/remotes/origin/main"
+    )
+
+    # Both CPU and trusted CUDA jobs must make the ancestry proof meaningful.
+    assert workflow.count(command) == 2

--- a/train_atomic_v2.py
+++ b/train_atomic_v2.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Train AtomicNNUEV2 from an authenticated atomic-bin-v2 manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+
+from atomic_v2.checkpoint import checkpoint_document
+from atomic_v2.dataset import (
+    create_provider,
+    validate_batch,
+    validate_train_validation_manifests,
+)
+from atomic_v2.model import AtomicNNUEV2
+from atomic_v2.serialization import write_nnue
+from atomic_v2.training import atomic_loss, create_optimizer, train_batch
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train the isolated AtomicNNUEV2 SFNNv15 backend from scratch."
+    )
+    parser.add_argument("--train", required=True, type=Path, help="atomic-bin-v2 training manifest")
+    parser.add_argument(
+        "--validation", required=True, type=Path, help="distinct atomic-bin-v2 validation manifest"
+    )
+    parser.add_argument("--output-checkpoint", required=True, type=Path)
+    parser.add_argument("--output-nnue", required=True, type=Path)
+    parser.add_argument("--steps", type=int, default=1)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help="positions per step; default 128 on CPU and 16384 on CUDA",
+    )
+    parser.add_argument(
+        "--validation-samples",
+        type=int,
+        default=1_000_000,
+        help="maximum validation positions; actual count is persisted",
+    )
+    parser.add_argument("--num-workers", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--learning-rate", type=float, default=1.5e-3)
+    parser.add_argument("--lambda", dest="lambda_", type=float, default=1.0)
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cpu")
+    parser.add_argument("--description", default="AtomicNNUEV2 initial trainer export")
+    return parser.parse_args()
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    for name in ("steps", "num_workers", "validation_samples"):
+        if getattr(args, name) <= 0:
+            raise ValueError(f"--{name.replace('_', '-')} must be positive")
+    if args.batch_size is not None and args.batch_size <= 0:
+        raise ValueError("--batch-size must be positive")
+    if args.seed < 0:
+        raise ValueError("--seed must be non-negative")
+    if not 0.0 <= args.lambda_ <= 1.0:
+        raise ValueError("--lambda must be in [0, 1]")
+    if args.output_checkpoint == args.output_nnue:
+        raise ValueError("checkpoint and NNUE outputs must be different paths")
+    for output in (args.output_checkpoint, args.output_nnue):
+        if output.exists() or output.with_name(output.name + ".tmp").exists():
+            raise FileExistsError(f"refusing to overwrite output: {output}")
+    if args.device == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("--device=cuda requested but CUDA is unavailable")
+
+
+def default_batch_size(device: str) -> int:
+    return 16_384 if torch.device(device).type == "cuda" else 128
+
+
+def _validation_loss(
+    model: AtomicNNUEV2,
+    batches,
+    lambda_: float,
+    *,
+    max_samples: int,
+) -> tuple[float, int]:
+    if max_samples <= 0:
+        raise ValueError("max_samples must be positive")
+    weighted_loss = 0.0
+    sample_count = 0
+    was_training = model.training
+    model.eval()
+    try:
+        with torch.no_grad():
+            for batch in batches:
+                values = validate_batch(batch)
+                remaining = max_samples - sample_count
+                if remaining <= 0:
+                    break
+                batch_samples = values[0].shape[0]
+                if batch_samples > remaining:
+                    values = tuple(value[:remaining] for value in values)
+                    batch_samples = remaining
+                inputs = values[:6] + values[8:]
+                prediction = model(*inputs)
+                loss = atomic_loss(prediction, values[6], values[7], lambda_=lambda_)
+                if not torch.isfinite(loss):
+                    raise FloatingPointError("Atomic V2 validation loss is not finite")
+                weighted_loss += float(loss) * batch_samples
+                sample_count += batch_samples
+                if sample_count >= max_samples:
+                    break
+    finally:
+        model.train(was_training)
+    if sample_count == 0:
+        raise ValueError("validation manifest yielded no records")
+    return weighted_loss / sample_count, sample_count
+
+
+def main() -> int:
+    args = parse_args()
+    _validate_args(args)
+    validate_train_validation_manifests(args.train, args.validation)
+    batch_size = args.batch_size or default_batch_size(args.device)
+
+    # Seed before model construction; official upstream currently seeds too
+    # late for this deterministic Atomic contract.
+    torch.manual_seed(args.seed)
+    if args.device == "cuda":
+        torch.cuda.manual_seed_all(args.seed)
+    model = AtomicNNUEV2().to(args.device)
+    optimizer = create_optimizer(model, args.learning_rate)
+    training = create_provider(
+        args.train,
+        batch_size=batch_size,
+        num_workers=args.num_workers,
+        device=args.device,
+        seed=args.seed,
+        cyclic=True,
+    )
+
+    losses = []
+    for _ in range(args.steps):
+        losses.append(train_batch(model, optimizer, next(training), lambda_=args.lambda_))
+
+    validation = create_provider(
+        args.validation,
+        batch_size=batch_size,
+        num_workers=args.num_workers,
+        device=args.device,
+        seed=args.seed,
+        cyclic=False,
+    )
+    validation_loss, validation_samples = _validation_loss(
+        model,
+        validation,
+        args.lambda_,
+        max_samples=args.validation_samples,
+    )
+
+    checkpoint_tmp = args.output_checkpoint.with_name(args.output_checkpoint.name + ".tmp")
+    nnue_tmp = args.output_nnue.with_name(args.output_nnue.name + ".tmp")
+    committed: list[Path] = []
+    try:
+        checkpoint = checkpoint_document(model, step=args.steps, optimizer=optimizer)
+        checkpoint["validation"] = {
+            "sample_budget": args.validation_samples,
+            "samples": validation_samples,
+            "loss": validation_loss,
+        }
+        torch.save(checkpoint, checkpoint_tmp)
+        with nnue_tmp.open("xb") as output:
+            write_nnue(output, model, args.description)
+        os.replace(checkpoint_tmp, args.output_checkpoint)
+        committed.append(args.output_checkpoint)
+        os.replace(nnue_tmp, args.output_nnue)
+        committed.append(args.output_nnue)
+    except BaseException:
+        checkpoint_tmp.unlink(missing_ok=True)
+        nnue_tmp.unlink(missing_ok=True)
+        # Outputs did not exist before the command, so removing a successfully
+        # renamed first member restores the all-or-nothing contract if the
+        # second rename fails.
+        for output in committed:
+            output.unlink(missing_ok=True)
+        raise
+
+    print(
+        json.dumps(
+            {
+                "backend": "atomic-nnue-v2",
+                "steps": args.steps,
+                "last_train_loss": losses[-1],
+                "validation_loss": validation_loss,
+                "validation_sample_budget": args.validation_samples,
+                "validation_samples": validation_samples,
+                "checkpoint": str(args.output_checkpoint),
+                "network": str(args.output_nnue),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## What changed

- add an isolated `atomic_v2` training package for the AtomicNNUEV2 contract
- reproduce the pinned SFNNv15 dense graph while retaining the 45,056-feature Legacy Atomic input layout
- add strict schema/hash validation, authenticated dataset loading, checkpoint validation, quantization and deterministic `.nnue` serialization
- add dedicated training and serialization CLIs without changing the Legacy Atomic V1 path
- lock PSQT, bucket, signed-LEB128, dense-layer and byte-exact serializer parity in tests

## Why

Atomic-Stockfish now has a separately selectable AtomicNNUEV2 backend. The trainer needs an independent, fail-closed producer for that wire format so engine, generator and trainer can be validated end to end without mutating the strongest Legacy V1 network contract.

V2 is intentionally a reproducible control backend: it modernizes the dense head to SFNNv15 but keeps the historical Atomic feature inputs. Atomic-specific threat features will be developed under a separately versioned V3 contract.

## Impact

- targets the project-specific `atomic` branch, not `main`
- leaves all existing Legacy V1 modules and serialization behavior unchanged
- rejects mismatched schemas, checkpoints, dimensions, hashes, malformed LEB128 and non-finite tensors
- emits the exact engine-compatible 46,780,619-byte diagnostic network layout

## Validation

- `python -m pytest -q`: **100 passed** on Python 3.12 / PyTorch 2.7.1
- deterministic serializer size: `46,780,619` bytes
- deterministic diagnostic SHA-256: `4DEB05CFF79B5D5EBA51C560F64ED24224671C188B6C5DB27521033E587C87C6`
- schema/contract, dataset, model, training-step, checkpoint and serialization negative-path tests
- `git diff --check`
