### PR TITLE
H9.3l-j: add isolated AtomicNNUEV3 trainer core

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 atomic_v2/schema/*.json text eol=lf
+tests/fixtures/atomic_v3/*.json text eol=lf

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - cuda

--- a/.github/workflows/trainer-tests.yml
+++ b/.github/workflows/trainer-tests.yml
@@ -15,6 +15,34 @@ permissions:
   contents: read
 
 jobs:
+  atomic-v3-python-compatibility:
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-CPU.txt
+
+      - name: Install isolated Atomic V3 import dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu torch==2.7.1+cpu
+          python -m pip install numpy==1.26.4
+
+      - name: Compile and import every Atomic V3 module
+        run: |
+          python -m compileall -q atomic_v3
+          python -c "import importlib, pkgutil, atomic_v3; modules = [item.name for item in pkgutil.iter_modules(atomic_v3.__path__, atomic_v3.__name__ + '.')]; [importlib.import_module(name) for name in modules]; print(len(modules), 'Atomic V3 modules imported')"
+
   cpu:
     timeout-minutes: 15
     strategy:

--- a/atomic_v3/__init__.py
+++ b/atomic_v3/__init__.py
@@ -1,0 +1,10 @@
+"""Explicit AtomicNNUEV3 trainer backend.
+
+Import submodules directly (``atomic_v3.model``, ``atomic_v3.dataset`` and
+``atomic_v3.training``).  No registration into the generic legacy feature-set
+dispatcher occurs in H9.3l-j.
+"""
+
+from .contract import BACKEND_KEY, BACKEND_NAME, FEATURE_NAME
+
+__all__ = ["BACKEND_KEY", "BACKEND_NAME", "FEATURE_NAME"]

--- a/atomic_v3/contract.py
+++ b/atomic_v3/contract.py
@@ -1,0 +1,228 @@
+"""Frozen AtomicNNUEV3 trainer-side architecture contract.
+
+This module intentionally does not participate in the legacy trainer or in
+``atomic_v2`` dispatch.  H9.3l-j needs an importable training graph, not a new
+generic feature-set alias, so every public identity is V3-specific.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+ENGINE_CONTRACT_COMMIT = "dde43fc08fb2bd45eec09d3dbe9f6d06845eeb24"
+ENGINE_CONTRACT_BLOB = "4ed24d80d07336497947b69a9d9a2ddffef25514"
+FEATURE_SCHEMA_SHA256 = "9d3c77a58e5e55ac1bc798dab41977451eb523fce1d6fd3ec3f7c1e574a78750"
+OFFICIAL_TRAINER_COMMIT = "b8512291deb4cd18afa67003bb6bc53dd522cbf0"
+
+# H9.3l-a publication boundary.  The trainer accepts an explicit validation
+# receipt bearing this schema identity; it never treats a campaign filename as
+# authentication by itself.
+CAMPAIGN_SCHEMA_SHA256 = "36a86983d63e71e20daa3bcf7a574dfc95abb544974e36c064445e79ad706517"
+CAMPAIGN_SCHEMA_BLOB = "41486135e3921f32ebabe0f070af1f2bd3f01b7a"
+PUBLICATION_VALIDATOR_CONTRACT = "atomic-v3-distributed-publication-h9.3l-a-v1"
+PUBLICATION_CONTRACT_COMMIT = ENGINE_CONTRACT_COMMIT
+PUBLICATION_SCHEMA_SHA256 = MappingProxyType({
+    "atomic-v3-dataset-campaign-v1.json": CAMPAIGN_SCHEMA_SHA256,
+    "atomic-v3-producer-attestation-v1.json": "de55f384fdea56fdb28addd50b78da7e0256b5a8857d5aec856219a3e922193e",
+    "atomic-v3-semantic-audit-v1.json": "e1aed04f4291f1ae514ba532b9a4c21fd926e41b7e29b7782a5222a85eda7810",
+    "atomic-v3-reachability-attestation-v1.json": "fb1af7130a2fa74be0fadd721db980269e12c89204b627eec63e6074ed3983e8",
+    "atomic-v3-training-environment-v1.json": "8e2f9b97183d3deedfbc1d03ac396ace7c069fc369af09db7e1ee693cd59f3d0",
+    "atomic-v3-training-run-manifest-v2.json": "7703f038262cd4a69299aeaf3e0bb35c6d3181029fd448f91560807a0507d184",
+})
+
+BACKEND_KEY = "atomic-nnue-v3"
+BACKEND_NAME = "AtomicNNUEV3"
+FEATURE_NAME = "HalfKAv2AtomicHM+CapturePair+KingBlastEP+BlastRing"
+
+FILE_VERSION = 0xA70C0003
+FEATURE_HASH = 0xA3FBDBE8
+TRANSFORMER_DESCRIPTOR_HASH = 0xCC31067A
+FEATURE_TRANSFORMER_HASH = 0x6FCAD592
+ARCHITECTURE_HASH = 0x63337116
+NETWORK_HASH = 0x0CF9A484
+
+ACCUMULATOR_DIMENSIONS = 1024
+PSQT_BUCKETS = 8
+LAYER_STACKS = 8
+
+HM_KING_BUCKETS = 32
+HM_TRAINING_PLANES = 12
+HM_PHYSICAL_PLANES = 11
+HM_ROWS_PER_BUCKET = 768
+HM_PHYSICAL_ROWS_PER_BUCKET = 704
+HM_TRAINING_DIMENSIONS = 24_576
+HM_PHYSICAL_DIMENSIONS = 22_528
+HM_VIRTUAL_DIMENSIONS = 768
+HM_OUTPUT_DIMENSIONS = ACCUMULATOR_DIMENSIONS + PSQT_BUCKETS
+HM_MAX_ACTIVE = 32
+
+CAPTURE_PAIR_DIMENSIONS = 40_012
+CAPTURE_PAIR_NORMAL_DIMENSIONS = 39_984
+CAPTURE_PAIR_GEOMETRY_DIMENSIONS = 3_332
+CAPTURE_PAIR_EP_EDGES_PER_RELATION = 14
+CAPTURE_PAIR_MAX_ACTIVE = 240
+
+KING_BLAST_EP_DIMENSIONS = 2_304
+KING_BLAST_EP_MAX_ACTIVE = 35
+
+BLAST_RING_DIMENSIONS = 10_240
+BLAST_RING_MAX_ACTIVE = 240
+
+PHYSICAL_DIMENSIONS = 75_084
+TRAINING_DIMENSIONS_EXCLUDING_VIRTUAL = 77_132
+TRAINING_PARAMETER_ROWS = 77_900
+MAX_ACTIVE_PHYSICAL = 547
+MAX_ACTIVE_FACTORIZED = 579
+
+FC0_INPUTS = 1024
+FC0_OUTPUTS = 32
+FC1_INPUTS = 64
+FC1_OUTPUTS = 32
+FC2_INPUTS = 128
+FC2_OUTPUTS = 1
+
+HM_DESCRIPTOR = (
+    "HalfKAv2Atomic_hm|v1|square=A1_0_rank_major|offset=0|"
+    "axes=king_bucket_h8_to_e1:32,piece_plane:OWN_P,OPP_P,OWN_N,OPP_N,"
+    "OWN_B,OPP_B,OWN_R,OPP_R,OWN_Q,OPP_Q,MERGED_K,square:64|physical=22528|"
+    "training_planes=OWN_P,OPP_P,OWN_N,OPP_N,OWN_B,OPP_B,OWN_R,OPP_R,"
+    "OWN_Q,OPP_Q,OWN_K,OPP_K|training=24576|virtual=768|"
+    "factor=bucket_plus_virtual_all_1032_then_export|"
+    "king_merge=opp_then_own_king_square_all_1032|"
+    "orientation=per_perspective_black_xor56_mirror_if_pre_h_king_file_lt4_"
+    "shared_all_slices|royal=KING|dtype=i16|"
+    "wire=i16_sleb_feature_major_output1024_contiguous_canonical_unpermuted_"
+    "permute16|psqt=hm_only_i32_sleb_feature_major_bucket8_contiguous_after_relations"
+)
+
+CAPTURE_PAIR_DESCRIPTOR = (
+    "AtomicCapturePair|v2-compact|square=A1_0_rank_major|offset=22528|"
+    "axes=normal:actor_rel_accumulator:OWN,OPP;edge:PAWN84@0,KNIGHT336@84,"
+    "BISHOP560@420,ROOK896@980,QUEEN1456@1876;target_enemy_of_actor:PAWN,"
+    "KNIGHT,BISHOP,ROOK,QUEEN,KING;normal_local=((actor_rel*3332+edge)*6+target)"
+    "@offset0_count39984;ep_tail=(actor_rel*14+ep_ordinal)@offset39984_count28;"
+    "ep_edges=OWN_rank5_to6_OPP_rank4_to3_oriented_from_then_center_asc|"
+    "physical=40012|physical_index=22528+local|"
+    "orientation=per_perspective_black_xor56_mirror_if_pre_h_king_file_lt4_"
+    "shared_all_slices|actor_rel=color_only|pawn_edge=OWN_north_OPP_south_no_extra_flip|"
+    "occupancy=stop_first_occupied_emit_enemy|pins_checks_self_blast=unfiltered|"
+    "promotion=one_pawn_relation_no_choice_expansion_current_piece_types|"
+    "ep=validated_stm_geometric_cold_tail_fail_closed_source_for_kbr_ring|"
+    "impossible_ep_rows=eliminated_no_holes|order=local_asc_unique|"
+    "ownership=caller_owned|thread=pure_reentrant_immutable_position|"
+    "king_actor=excluded|pawn_push=excluded|dtype=i8|"
+    "wire=i8_raw_signed_twos_feature_major_output1024_contiguous_canonical_"
+    "unpermuted_permute8_after_hm|psqt=none"
+)
+
+KING_BLAST_EP_DESCRIPTOR = (
+    "AtomicKingBlastEP|v1|offset=62540|axes=center:64;actor_rel_accumulator:OWN,OPP;"
+    "king_rel_actor:ENEMY_KING_CENTER,ENEMY_KING_N,ENEMY_KING_NE,ENEMY_KING_E,"
+    "ENEMY_KING_SE,ENEMY_KING_S,ENEMY_KING_SW,ENEMY_KING_W,ENEMY_KING_NW,"
+    "OWN_KING_N,OWN_KING_NE,OWN_KING_E,OWN_KING_SE,OWN_KING_S,OWN_KING_SW,"
+    "OWN_KING_W,OWN_KING_NW;class:EN_PASSANT_MARKER|"
+    "local=((center*2+actor_rel)*18+class)@0..2303|physical=2304@62540..64843|"
+    "orientation=per_perspective_black_xor56_mirror_if_pre_h_king_file_lt4_"
+    "shared_all_slices|source=single_exact_unfiltered_cp_emission_including_"
+    "validated_geometric_ep|offset=related_king_minus_center_in_joint_frame_exact_dfdr|"
+    "activation=boolean_sorted_unique_capture_center_set|ep=landing_center_dedup_"
+    "offcenter_pawn_excluded_fail_closed|rectangle=full_no_holes|"
+    "error=cp_mapped_empty_no_partial|ownership=caller_owned|"
+    "thread=pure_reentrant_immutable_position|max=17x2_plus1_eq35|dtype=i16|"
+    "wire=i16_sleb_feature_major_output1024_contiguous_canonical_unpermuted_"
+    "permute16_after_capture_pair|psqt=none"
+)
+
+BLAST_RING_DESCRIPTOR = (
+    "AtomicBlastRing|v1|offset=64844|axes=center:64;actor_rel_accumulator:OWN,OPP;"
+    "collateral_rel_accumulator:OWN,OPP;offset:N,NE,E,SE,S,SW,W,NW;class:KNIGHT,"
+    "BISHOP,ROOK,QUEEN,ADJACENT_PAWN_SURVIVES|local=((((center*2+actor_rel)*2+"
+    "collateral_rel)*8+offset)*5+class)@0..10239|physical=10240@64844..75083|"
+    "orientation=per_perspective_black_xor56_mirror_if_pre_h_king_file_lt4_"
+    "shared_all_slices|source=single_exact_unfiltered_cp_emission_including_"
+    "validated_geometric_ep|group=center_actor_rel_distinct_origins|"
+    "offset=collateral_minus_center_in_joint_frame_exact_dfdr|"
+    "activation=boolean_sorted_unique_capture_center_union|"
+    "origin=exclude_only_single_distinct_origin_group_retain_all_origins_if_multi|"
+    "nonpawn=current_NBRQ_explodes|pawn=adjacent_survives_except_single_origin_or_ep_"
+    "captured|ep=landing_center_malformed_omitted_normal_preserved|"
+    "ep_captured_pawn=oriented_center_minus_own8_or_opp_minus8_always_excluded_even_multi|"
+    "kings=separate|rectangle=full_no_holes|error=cp_mapped_empty_no_partial|"
+    "ownership=caller_owned|thread=pure_reentrant_immutable_position|max=30x8_eq240|"
+    "dtype=i8|wire=i8_raw_signed_twos_feature_major_output1024_contiguous_canonical_"
+    "unpermuted_permute8_after_king_blast|psqt=none"
+)
+
+# This is the global mixed-wire descriptor frozen by the engine in H9.3g.
+# Keep the complete ASCII payload here rather than trusting the precomputed
+# hash alone: the trainer serializer introduced in H9.3l-k must emit exactly
+# the same contract bytes as C++ and the independent wire oracle.
+TRANSFORMER_DESCRIPTOR = (
+    "AtomicNNUEV3Transformer|v1|wire=biases:i16_sleb[1024],hm:i16_sleb[22528x1024],"
+    "cp:i8_raw[40012x1024],kbr:i16_sleb[2304x1024],ring:i8_raw[10240x1024],hm_psqt:"
+    "i32_sleb[22528x8],dense:8x(architecture_hash_u32=0x63337116,sfnnv15)|layout=each_"
+    "feature_slice_feature_major_output1024_contiguous;hm_psqt_feature_major_bucket8_"
+    "contiguous|sleb=COMPRESSED_LEB128_then_u32_le_byte_count_canonical_signed|file=canonical_"
+    "unpermuted|raw_i8=signed_twos_complement|load_permute=biases,hm,kbr:i16_block16;cp,"
+    "ring:i8_block8;hm_psqt:none|permute_order=avx512[0,2,4,6,1,3,5,7],avx2_lasx[0,2,1,"
+    "3,4,6,5,7],other[0,1,2,3,4,5,6,7]|save=unpermute_copy_inverse_order_no_live_"
+    "mutation|psqt=hm_only_same_virtual_factor_coalesce_and_12to11_export|dense_tail=byte_"
+    "identical_atomic_v2_sfnnv15_architecture_0x63337116|strict_eof=true"
+)
+
+
+def fnv1a_32(data: bytes) -> int:
+    value = 0x811C9DC5
+    for byte in data:
+        value = ((value ^ byte) * 0x01000193) & 0xFFFFFFFF
+    return value
+
+
+def _rotate_left_one(value: int) -> int:
+    return ((value << 1) | (value >> 31)) & 0xFFFFFFFF
+
+
+SLICE_HASHES = (
+    fnv1a_32(HM_DESCRIPTOR.encode("ascii")),
+    fnv1a_32(CAPTURE_PAIR_DESCRIPTOR.encode("ascii")),
+    fnv1a_32(KING_BLAST_EP_DESCRIPTOR.encode("ascii")),
+    fnv1a_32(BLAST_RING_DESCRIPTOR.encode("ascii")),
+)
+
+
+def fold_slice_hashes(values: tuple[int, ...] = SLICE_HASHES) -> int:
+    folded = 0
+    for value in values:
+        folded = _rotate_left_one(folded) ^ value
+    return folded
+
+
+@dataclass(frozen=True)
+class SliceContract:
+    key: str
+    dimensions: int
+    outputs: int
+    integer_bits: int
+    max_active: int
+    has_psqt: bool = False
+
+
+SLICES = (
+    SliceContract("half_ka_v2_atomic_hm", HM_TRAINING_DIMENSIONS, HM_OUTPUT_DIMENSIONS, 16, HM_MAX_ACTIVE, True),
+    SliceContract("atomic_capture_pair", CAPTURE_PAIR_DIMENSIONS, ACCUMULATOR_DIMENSIONS, 8, CAPTURE_PAIR_MAX_ACTIVE),
+    SliceContract("atomic_king_blast_ep", KING_BLAST_EP_DIMENSIONS, ACCUMULATOR_DIMENSIONS, 16, KING_BLAST_EP_MAX_ACTIVE),
+    SliceContract("atomic_blast_ring", BLAST_RING_DIMENSIONS, ACCUMULATOR_DIMENSIONS, 8, BLAST_RING_MAX_ACTIVE),
+)
+
+
+assert SLICE_HASHES == (0xA34A8666, 0x9AEDB186, 0xF5172BC0, 0x38377946)
+assert fold_slice_hashes() == FEATURE_HASH
+assert len(TRANSFORMER_DESCRIPTOR.encode("ascii")) == 799
+assert fnv1a_32(TRANSFORMER_DESCRIPTOR.encode("ascii")) == TRANSFORMER_DESCRIPTOR_HASH
+assert FEATURE_TRANSFORMER_HASH == (FEATURE_HASH ^ 2048 ^ TRANSFORMER_DESCRIPTOR_HASH)
+assert NETWORK_HASH == (FEATURE_TRANSFORMER_HASH ^ ARCHITECTURE_HASH)
+assert HM_TRAINING_DIMENSIONS + CAPTURE_PAIR_DIMENSIONS + KING_BLAST_EP_DIMENSIONS + BLAST_RING_DIMENSIONS == TRAINING_DIMENSIONS_EXCLUDING_VIRTUAL
+assert TRAINING_DIMENSIONS_EXCLUDING_VIRTUAL + HM_VIRTUAL_DIMENSIONS == TRAINING_PARAMETER_ROWS
+assert HM_MAX_ACTIVE + CAPTURE_PAIR_MAX_ACTIVE + KING_BLAST_EP_MAX_ACTIVE + BLAST_RING_MAX_ACTIVE == MAX_ACTIVE_PHYSICAL

--- a/atomic_v3/dataset.py
+++ b/atomic_v3/dataset.py
@@ -120,14 +120,33 @@ def _reject_linked_path_components(path: Path) -> None:
             )
 
 
+@dataclass(frozen=True)
+class _AuthenticatedFileSnapshot:
+    """Immutable bytes and lexical label captured by one authenticated read.
+
+    ``path`` is an absolute lexical provenance label, not later path authority.
+    It is fixed before opening and never replaced by a post-authentication
+    ``resolve()`` whose result could point through a raced symlink or parent.
+    """
+
+    path: Path
+    identity: tuple[int, int, int, int]
+    sha256: str
+    payload: bytes
+
+
 def _read_regular_authenticated(
     path: Path,
     expected_sha256: str,
     *,
     expected_bytes: Optional[int] = None,
     maximum: Optional[int] = None,
-) -> bytes:
+) -> _AuthenticatedFileSnapshot:
     expected_sha256 = _require_sha256("expected_sha256", expected_sha256)
+    # Freeze the non-authoritative provenance label before any filesystem I/O.
+    # Never call resolve() after authentication: an attacker could swap the
+    # just-read path to a symlink between those two operations.
+    path = Path(os.path.abspath(str(path)))
     _reject_linked_path_components(path)
     try:
         path_before = os.lstat(path)
@@ -180,7 +199,12 @@ def _read_regular_authenticated(
         raise DatasetContractError(
             f"artifact SHA-256 mismatch for {path.name}: expected {expected_sha256}, got {actual}"
         )
-    return payload
+    return _AuthenticatedFileSnapshot(
+        path=path,
+        identity=_file_identity(after),
+        sha256=actual,
+        payload=payload,
+    )
 
 
 @dataclass(frozen=True)
@@ -239,7 +263,8 @@ def _load_publication_receipt(
 ) -> PublicationReceiptSnapshot:
     path = _require_path("receipt_path", receipt_path)
     expected = _require_sha256("expected_receipt_sha256", expected_receipt_sha256)
-    raw = _read_regular_authenticated(path, expected, maximum=MAX_RECEIPT_BYTES)
+    artifact = _read_regular_authenticated(path, expected, maximum=MAX_RECEIPT_BYTES)
+    raw = artifact.payload
     document = _strict_json_document(raw, "publication receipt")
     if set(document) != _RECEIPT_KEYS:
         raise DatasetContractError("publication receipt fields differ from the frozen contract")
@@ -268,7 +293,7 @@ def _load_publication_receipt(
     if document["dataset_publication_ready"] is not True:
         raise DatasetContractError("campaign is not dataset-publication-ready")
     return PublicationReceiptSnapshot(
-        receipt_path=path.resolve(strict=True),
+        receipt_path=artifact.path,
         receipt_sha256=expected,
         validator_contract=document["validator_contract"],
         publication_contract_commit=document["publication_contract_commit"],
@@ -329,10 +354,17 @@ def _artifact_manifest(
     if descriptor["schema_sha256"] != ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256:
         raise DatasetContractError("campaign role does not reference the pinned Atomic BIN V2 manifest schema")
     path = root / filename
-    payload = _read_regular_authenticated(
+    artifact = _read_regular_authenticated(
         path, digest, expected_bytes=byte_count, maximum=MAX_CAMPAIGN_BYTES
     )
-    return RoleManifest(chunk_index, first_record, records, path, digest, payload)
+    return RoleManifest(
+        chunk_index,
+        first_record,
+        records,
+        artifact.path,
+        digest,
+        artifact.payload,
+    )
 
 
 def _authenticate_campaign_roles(
@@ -342,10 +374,11 @@ def _authenticate_campaign_roles(
 ) -> CampaignInspectionSnapshot:
     receipt = _load_publication_receipt(receipt_path, expected_receipt_sha256)
     supplied_path = _require_path("campaign_path", campaign_path)
-    raw = _read_regular_authenticated(
+    campaign_artifact = _read_regular_authenticated(
         supplied_path, receipt.campaign_sha256, maximum=MAX_CAMPAIGN_BYTES
     )
-    path = supplied_path.resolve(strict=True)
+    raw = campaign_artifact.payload
+    path = campaign_artifact.path
     document = _strict_json_document(raw, "campaign")
     if document.get("schema_version") != 1 or document.get("status") != "completed":
         raise DatasetContractError("campaign is not a completed schema_version 1 document")
@@ -792,13 +825,10 @@ def load_canonical_fixture(
 ) -> CanonicalFixture:
     if path is None:
         path = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "atomic_v3" / "trainer-core-v1.json"
-    supplied_path = Path(path)
-    if supplied_path.is_symlink():
-        raise DatasetContractError("fixture symbolic links are forbidden")
-    fixture_path = supplied_path.resolve(strict=True)
-    raw = _read_regular_authenticated(
-        fixture_path, CANONICAL_FIXTURE_SHA256, maximum=1024 * 1024
+    fixture_artifact = _read_regular_authenticated(
+        Path(path), CANONICAL_FIXTURE_SHA256, maximum=1024 * 1024
     )
+    raw = fixture_artifact.payload
     try:
         document = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys)
     except DatasetContractError:

--- a/atomic_v3/dataset.py
+++ b/atomic_v3/dataset.py
@@ -1,0 +1,839 @@
+"""Authenticated campaign-file seam and strict AtomicNNUEV3 tensor batches.
+
+H9.3l-a owns publication validation.  The trust anchor here is the exact
+SHA-256 of a strict receipt file, delivered out-of-process by the authenticated
+controller/CAS.  Python objects are not authentication capabilities: arbitrary
+code in this process is inside the trust boundary.  Every provider creation
+re-reads the receipt, campaign and ordered manifests from stable file
+descriptors before the factory sees an immutable byte snapshot.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, Mapping, Optional, Sequence, Union
+
+import torch
+
+from .contract import (
+    BLAST_RING_MAX_ACTIVE,
+    CAMPAIGN_SCHEMA_SHA256,
+    CAPTURE_PAIR_MAX_ACTIVE,
+    FEATURE_SCHEMA_SHA256,
+    HM_MAX_ACTIVE,
+    HM_ROWS_PER_BUCKET,
+    KING_BLAST_EP_MAX_ACTIVE,
+    PUBLICATION_CONTRACT_COMMIT,
+    PUBLICATION_SCHEMA_SHA256,
+    PUBLICATION_VALIDATOR_CONTRACT,
+    SLICES,
+)
+from .indices import Perspective, make_joint_orientation, network_bucket
+
+
+ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256 = (
+    "83d63922df3ac4a0c81a21ec9d9fd9e180efe50f26efee62fe01710e09da5b42"
+)
+MAX_CAMPAIGN_BYTES = 16 * 1024 * 1024
+MAX_RECEIPT_BYTES = 64 * 1024
+PUBLICATION_RECEIPT_FORMAT = "atomic-v3-publication-validation-receipt-v1"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_BASENAME_RE = re.compile(r'^(?!\.{1,2}$)[^/\\:\x00<>"|?*]+$')
+_REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x400)
+
+
+class DatasetContractError(ValueError):
+    pass
+
+
+def _is_plain_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _require_sha256(name: str, value: object) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise DatasetContractError(f"{name} must be lowercase SHA-256 hex")
+    return value
+
+
+def _require_uint_string(name: str, value: object, *, positive: bool = False) -> int:
+    if not isinstance(value, str) or not value.isascii() or not value.isdecimal():
+        raise DatasetContractError(f"{name} must be a canonical decimal string")
+    if value != "0" and value.startswith("0"):
+        raise DatasetContractError(f"{name} has a leading zero")
+    number = int(value)
+    if number > (1 << 64) - 1 or (positive and number == 0):
+        raise DatasetContractError(f"{name} is outside its uint64 domain")
+    return number
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    document: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in document:
+            raise DatasetContractError(f"duplicate JSON property: {key}")
+        document[key] = value
+    return document
+
+
+def _reject_json_constant(value: str) -> None:
+    raise DatasetContractError(f"nonstandard JSON constant is forbidden: {value}")
+
+
+def _require_path(name: str, value: object) -> Path:
+    if not isinstance(value, (str, os.PathLike)):
+        raise TypeError(f"{name} must be a filesystem path")
+    return Path(value)
+
+
+def _file_identity(value: os.stat_result) -> tuple[int, int, int, int]:
+    return value.st_dev, value.st_ino, value.st_size, value.st_mtime_ns
+
+
+def _is_link_or_reparse(value: os.stat_result) -> bool:
+    attributes = getattr(value, "st_file_attributes", 0)
+    return stat.S_ISLNK(value.st_mode) or bool(attributes & _REPARSE_POINT)
+
+
+def _reject_linked_path_components(path: Path) -> None:
+    """Reject symlinks and Windows reparse points in the complete path."""
+
+    absolute = Path(os.path.abspath(str(path)))
+    current = Path(absolute.anchor)
+    for component in absolute.parts[1:]:
+        current /= component
+        try:
+            metadata = os.lstat(current)
+        except OSError as error:
+            raise DatasetContractError(
+                f"cannot stat authenticated path component {current}: {error}"
+            ) from error
+        if _is_link_or_reparse(metadata):
+            raise DatasetContractError(
+                f"symbolic links and reparse points are forbidden: {current}"
+            )
+
+
+def _read_regular_authenticated(
+    path: Path,
+    expected_sha256: str,
+    *,
+    expected_bytes: Optional[int] = None,
+    maximum: Optional[int] = None,
+) -> bytes:
+    expected_sha256 = _require_sha256("expected_sha256", expected_sha256)
+    _reject_linked_path_components(path)
+    try:
+        path_before = os.lstat(path)
+    except OSError as error:
+        raise DatasetContractError(f"cannot stat authenticated artifact {path}: {error}") from error
+    if _is_link_or_reparse(path_before):
+        raise DatasetContractError(f"symbolic links and reparse points are forbidden: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise DatasetContractError(f"cannot open authenticated artifact {path}: {error}") from error
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode):
+            raise DatasetContractError(f"artifact is not a regular file: {path}")
+        if _file_identity(path_before) != _file_identity(before):
+            raise DatasetContractError(f"artifact path changed before authentication: {path}")
+        if expected_bytes is not None and before.st_size != expected_bytes:
+            raise DatasetContractError(
+                f"artifact byte count mismatch for {path.name}: {before.st_size} != {expected_bytes}"
+            )
+        if maximum is not None and before.st_size > maximum:
+            raise DatasetContractError(f"artifact exceeds byte limit: {path}")
+        chunks: list[bytes] = []
+        bytes_read = 0
+        while True:
+            block = os.read(descriptor, 1024 * 1024)
+            if not block:
+                break
+            chunks.append(block)
+            bytes_read += len(block)
+            if maximum is not None and bytes_read > maximum:
+                raise DatasetContractError(f"artifact exceeds byte limit while reading: {path}")
+        after = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if _file_identity(before) != _file_identity(after):
+        raise DatasetContractError(f"artifact changed while authenticating: {path}")
+    try:
+        path_after = os.lstat(path)
+    except OSError as error:
+        raise DatasetContractError(f"artifact path vanished while authenticating: {path}") from error
+    _reject_linked_path_components(path)
+    if _is_link_or_reparse(path_after) or _file_identity(path_after) != _file_identity(after):
+        raise DatasetContractError(f"artifact path changed while authenticating: {path}")
+    payload = b"".join(chunks)
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != expected_sha256:
+        raise DatasetContractError(
+            f"artifact SHA-256 mismatch for {path.name}: expected {expected_sha256}, got {actual}"
+        )
+    return payload
+
+
+@dataclass(frozen=True)
+class PublicationReceiptSnapshot:
+    """Strict receipt values authenticated by an external expected SHA-256."""
+
+    receipt_path: Path
+    receipt_sha256: str
+    validator_contract: str
+    publication_contract_commit: str
+    publication_schema_sha256: tuple[tuple[str, str], ...]
+    campaign_schema_sha256: str
+    campaign_sha256: str
+    collection_sha256: str
+    feature_schema_sha256: str
+    producer_attestation_sha256: str
+    semantic_audit_sha256: str
+    reachability_attestation_sha256: str
+    dataset_publication_ready: bool
+
+
+_RECEIPT_KEYS = {
+    "receipt_format",
+    "validator_contract",
+    "publication_contract_commit",
+    "publication_schema_sha256",
+    "campaign_schema_sha256",
+    "campaign_sha256",
+    "collection_sha256",
+    "feature_schema_sha256",
+    "producer_attestation_sha256",
+    "semantic_audit_sha256",
+    "reachability_attestation_sha256",
+    "dataset_publication_ready",
+}
+
+
+def _strict_json_document(payload: bytes, label: str) -> dict[str, Any]:
+    try:
+        document = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except DatasetContractError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DatasetContractError(f"{label} is not strict UTF-8 JSON: {error}") from error
+    if not isinstance(document, dict):
+        raise DatasetContractError(f"{label} root must be an object")
+    return document
+
+
+def _load_publication_receipt(
+    receipt_path: Union[str, Path], expected_receipt_sha256: str
+) -> PublicationReceiptSnapshot:
+    path = _require_path("receipt_path", receipt_path)
+    expected = _require_sha256("expected_receipt_sha256", expected_receipt_sha256)
+    raw = _read_regular_authenticated(path, expected, maximum=MAX_RECEIPT_BYTES)
+    document = _strict_json_document(raw, "publication receipt")
+    if set(document) != _RECEIPT_KEYS:
+        raise DatasetContractError("publication receipt fields differ from the frozen contract")
+    if document["receipt_format"] != PUBLICATION_RECEIPT_FORMAT:
+        raise DatasetContractError("unrecognized publication receipt format")
+    if document["validator_contract"] != PUBLICATION_VALIDATOR_CONTRACT:
+        raise DatasetContractError("unrecognized publication validator contract")
+    if document["publication_contract_commit"] != PUBLICATION_CONTRACT_COMMIT:
+        raise DatasetContractError("publication receipt commit is not the merged H9.3l-a contract")
+    schemas = document["publication_schema_sha256"]
+    if not isinstance(schemas, dict) or schemas != dict(PUBLICATION_SCHEMA_SHA256):
+        raise DatasetContractError("publication receipt schema set differs from merged H9.3l-a")
+    if document["campaign_schema_sha256"] != CAMPAIGN_SCHEMA_SHA256:
+        raise DatasetContractError("campaign schema is not the release-pinned H9.3l-a schema")
+    if document["feature_schema_sha256"] != FEATURE_SCHEMA_SHA256:
+        raise DatasetContractError("receipt feature schema does not match AtomicNNUEV3")
+    digest_fields = (
+        "campaign_sha256",
+        "collection_sha256",
+        "producer_attestation_sha256",
+        "semantic_audit_sha256",
+        "reachability_attestation_sha256",
+    )
+    for field_name in digest_fields:
+        _require_sha256(field_name, document[field_name])
+    if document["dataset_publication_ready"] is not True:
+        raise DatasetContractError("campaign is not dataset-publication-ready")
+    return PublicationReceiptSnapshot(
+        receipt_path=path.resolve(strict=True),
+        receipt_sha256=expected,
+        validator_contract=document["validator_contract"],
+        publication_contract_commit=document["publication_contract_commit"],
+        publication_schema_sha256=tuple(sorted(schemas.items())),
+        campaign_schema_sha256=document["campaign_schema_sha256"],
+        campaign_sha256=document["campaign_sha256"],
+        collection_sha256=document["collection_sha256"],
+        feature_schema_sha256=document["feature_schema_sha256"],
+        producer_attestation_sha256=document["producer_attestation_sha256"],
+        semantic_audit_sha256=document["semantic_audit_sha256"],
+        reachability_attestation_sha256=document["reachability_attestation_sha256"],
+        dataset_publication_ready=True,
+    )
+
+
+@dataclass(frozen=True)
+class RoleManifest:
+    chunk_index: int
+    first_record: int
+    records: int
+    path: Path
+    sha256: str
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class CampaignInspectionSnapshot:
+    """Fresh authenticated bytes for inspection, never an authority token."""
+
+    receipt: PublicationReceiptSnapshot
+    campaign_path: Path
+    campaign_payload: bytes
+    campaign_id: str
+    train: tuple[RoleManifest, ...]
+    validation: tuple[RoleManifest, ...]
+
+    def manifests(self, role: Literal["train", "validation"]) -> tuple[RoleManifest, ...]:
+        if role == "train":
+            return self.train
+        if role == "validation":
+            return self.validation
+        raise DatasetContractError("role must be exactly 'train' or 'validation'")
+
+
+def _artifact_manifest(
+    root: Path, descriptor: object, *, chunk_index: int, first_record: int, records: int
+) -> RoleManifest:
+    if not isinstance(descriptor, Mapping):
+        raise DatasetContractError("campaign role manifest descriptor must be an object")
+    required = {"file", "bytes", "sha256", "schema_sha256"}
+    if set(descriptor) != required:
+        raise DatasetContractError("campaign role manifest descriptor fields differ")
+    filename = descriptor["file"]
+    if not isinstance(filename, str) or _BASENAME_RE.fullmatch(filename) is None:
+        raise DatasetContractError("campaign role manifest file is not a safe basename")
+    byte_count = _require_uint_string("manifest.bytes", descriptor["bytes"], positive=True)
+    digest = _require_sha256("manifest.sha256", descriptor["sha256"])
+    if descriptor["schema_sha256"] != ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256:
+        raise DatasetContractError("campaign role does not reference the pinned Atomic BIN V2 manifest schema")
+    path = root / filename
+    payload = _read_regular_authenticated(
+        path, digest, expected_bytes=byte_count, maximum=MAX_CAMPAIGN_BYTES
+    )
+    return RoleManifest(chunk_index, first_record, records, path, digest, payload)
+
+
+def _authenticate_campaign_roles(
+    campaign_path: Union[str, Path],
+    receipt_path: Union[str, Path],
+    expected_receipt_sha256: str,
+) -> CampaignInspectionSnapshot:
+    receipt = _load_publication_receipt(receipt_path, expected_receipt_sha256)
+    supplied_path = _require_path("campaign_path", campaign_path)
+    raw = _read_regular_authenticated(
+        supplied_path, receipt.campaign_sha256, maximum=MAX_CAMPAIGN_BYTES
+    )
+    path = supplied_path.resolve(strict=True)
+    document = _strict_json_document(raw, "campaign")
+    if document.get("schema_version") != 1 or document.get("status") != "completed":
+        raise DatasetContractError("campaign is not a completed schema_version 1 document")
+    if document.get("collection_sha256") != receipt.collection_sha256:
+        raise DatasetContractError("campaign collection hash does not match validation receipt")
+    schemas = document.get("schemas")
+    if not isinstance(schemas, Mapping) or schemas.get("feature") != FEATURE_SCHEMA_SHA256:
+        raise DatasetContractError("campaign does not bind the frozen AtomicNNUEV3 feature schema")
+    campaign_id = document.get("campaign_id")
+    if not isinstance(campaign_id, str) or not campaign_id:
+        raise DatasetContractError("campaign_id is missing")
+    chunks = document.get("chunks")
+    if not isinstance(chunks, list) or not chunks:
+        raise DatasetContractError("campaign chunks must be a non-empty array")
+
+    roles: dict[str, list[RoleManifest]] = {"train": [], "validation": []}
+    expected_chunk = None
+    expected_offsets = {"train": 0, "validation": 0}
+    manifest_names: set[str] = set()
+    manifest_hashes: set[str] = set()
+    for offset, chunk in enumerate(chunks):
+        if not isinstance(chunk, Mapping):
+            raise DatasetContractError("campaign chunk must be an object")
+        chunk_index = _require_uint_string(f"chunks[{offset}].index", chunk.get("index"))
+        if expected_chunk is None:
+            expected_chunk = chunk_index
+        if chunk_index != expected_chunk:
+            raise DatasetContractError("campaign chunk indices are not contiguous")
+        expected_chunk += 1
+        for role in ("train", "validation"):
+            partition = chunk.get(role)
+            if not isinstance(partition, Mapping):
+                raise DatasetContractError(f"chunk {chunk_index} is missing {role} partition")
+            first_record = _require_uint_string(
+                f"chunks[{offset}].{role}.first_record", partition.get("first_record")
+            )
+            records = _require_uint_string(
+                f"chunks[{offset}].{role}.records", partition.get("records"), positive=True
+            )
+            if first_record != expected_offsets[role]:
+                raise DatasetContractError(f"campaign {role} record offsets are not contiguous")
+            expected_offsets[role] += records
+            manifest = _artifact_manifest(
+                path.parent,
+                partition.get("manifest"),
+                chunk_index=chunk_index,
+                first_record=first_record,
+                records=records,
+            )
+            if manifest.path.name in manifest_names or manifest.sha256 in manifest_hashes:
+                raise DatasetContractError("campaign reuses a role manifest artifact")
+            manifest_names.add(manifest.path.name)
+            manifest_hashes.add(manifest.sha256)
+            roles[role].append(manifest)
+
+    totals = document.get("totals")
+    if not isinstance(totals, Mapping):
+        raise DatasetContractError("campaign totals are missing")
+    for role in ("train", "validation"):
+        declared = _require_uint_string(
+            f"totals.{role}_records", totals.get(f"{role}_records"), positive=True
+        )
+        if declared != expected_offsets[role]:
+            raise DatasetContractError(f"campaign {role} total does not match ordered manifests")
+    declared_total = _require_uint_string("totals.records", totals.get("records"), positive=True)
+    if declared_total != expected_offsets["train"] + expected_offsets["validation"]:
+        raise DatasetContractError("campaign aggregate record total is inconsistent")
+
+    return CampaignInspectionSnapshot(
+        receipt=receipt,
+        campaign_path=path,
+        campaign_payload=raw,
+        campaign_id=campaign_id,
+        train=tuple(roles["train"]),
+        validation=tuple(roles["validation"]),
+    )
+
+
+def inspect_campaign_roles(
+    campaign_path: Union[str, Path],
+    receipt_path: Union[str, Path],
+    expected_receipt_sha256: str,
+) -> CampaignInspectionSnapshot:
+    """Return a non-authoritative snapshot using a controller/CAS digest."""
+
+    return _authenticate_campaign_roles(
+        campaign_path, receipt_path, expected_receipt_sha256
+    )
+
+
+def create_role_provider(
+    campaign_path: Union[str, Path],
+    receipt_path: Union[str, Path],
+    expected_receipt_sha256: str,
+    role: Literal["train", "validation"],
+    *,
+    provider_factory: Callable[..., Any],
+    **provider_options: Any,
+) -> Any:
+    """Reauthenticate from an externally pinned receipt, then invoke V3.
+
+    ``expected_receipt_sha256`` must be supplied by the authenticated external
+    controller/CAS.  This function never derives or substitutes that trust
+    anchor and has no legacy or loader-autodetection fallback.
+    """
+
+    if not callable(provider_factory):
+        raise TypeError("provider_factory must be callable")
+    snapshot = _authenticate_campaign_roles(
+        campaign_path, receipt_path, expected_receipt_sha256
+    )
+    manifests = snapshot.manifests(role)
+    receipt = snapshot.receipt
+    return provider_factory(
+        backend="atomic-nnue-v3",
+        role=role,
+        receipt_path=str(receipt.receipt_path),
+        receipt_sha256=receipt.receipt_sha256,
+        campaign_path=str(snapshot.campaign_path),
+        campaign_sha256=receipt.campaign_sha256,
+        collection_sha256=receipt.collection_sha256,
+        producer_attestation_sha256=receipt.producer_attestation_sha256,
+        semantic_audit_sha256=receipt.semantic_audit_sha256,
+        reachability_attestation_sha256=receipt.reachability_attestation_sha256,
+        manifests=tuple(str(item.path) for item in manifests),
+        manifest_sha256=tuple(item.sha256 for item in manifests),
+        manifest_records=tuple(item.records for item in manifests),
+        manifest_payloads=tuple(item.payload for item in manifests),
+        **provider_options,
+    )
+
+
+@dataclass(frozen=True)
+class SparseSliceBatch:
+    indices: torch.Tensor
+    values: torch.Tensor
+
+
+@dataclass(frozen=True)
+class PerspectiveBatch:
+    own_king_squares: torch.Tensor
+    hm: SparseSliceBatch
+    capture_pair: SparseSliceBatch
+    king_blast_ep: SparseSliceBatch
+    blast_ring: SparseSliceBatch
+
+
+@dataclass(frozen=True)
+class AtomicV3Batch:
+    side_to_move_white: torch.Tensor
+    piece_counts: torch.Tensor
+    white: PerspectiveBatch
+    black: PerspectiveBatch
+    outcome: torch.Tensor
+    score: torch.Tensor
+    bucket_indices: torch.Tensor
+
+    @property
+    def batch_size(self) -> int:
+        return int(self.side_to_move_white.shape[0])
+
+
+def _validate_sparse_slice(
+    name: str,
+    value: SparseSliceBatch,
+    *,
+    batch_size: int,
+    dimensions: int,
+    max_active: int,
+    require_active: bool,
+    sorted_unique: bool,
+) -> None:
+    if not isinstance(value, SparseSliceBatch):
+        raise DatasetContractError(f"{name} must be SparseSliceBatch")
+    indices, values = value.indices, value.values
+    if indices.ndim != 2 or indices.shape[0] != batch_size or values.shape != indices.shape:
+        raise DatasetContractError(f"{name} indices/values must have equal [batch, width] shape")
+    if indices.shape[1] < 1 or indices.shape[1] > max_active:
+        raise DatasetContractError(f"{name} width exceeds frozen active bound")
+    if indices.dtype != torch.int32 or values.dtype != torch.float32:
+        raise DatasetContractError(f"{name} requires int32 indices and float32 values")
+    if indices.device != values.device:
+        raise DatasetContractError(f"{name} indices and values use different devices")
+    if not torch.all(torch.isfinite(values)):
+        raise DatasetContractError(f"{name} values are not finite")
+    for row_index in range(batch_size):
+        row = indices[row_index].tolist()
+        active: list[int] = []
+        empty_seen = False
+        for column, index in enumerate(row):
+            if index == -1:
+                empty_seen = True
+                if float(values[row_index, column]) != 0.0:
+                    raise DatasetContractError(f"{name} empty sentinel has nonzero value")
+                continue
+            if empty_seen:
+                raise DatasetContractError(f"{name} uses a non-suffix empty sentinel")
+            if index < 0 or index >= dimensions:
+                raise DatasetContractError(f"{name} index {index} escapes [0, {dimensions - 1}]")
+            if float(values[row_index, column]) != 1.0:
+                raise DatasetContractError(f"{name} active features must be boolean one")
+            active.append(index)
+        if require_active and not active:
+            raise DatasetContractError(f"{name} must contain an active feature")
+        if len(active) != len(set(active)):
+            raise DatasetContractError(f"{name} contains duplicate active indices")
+        if sorted_unique and active != sorted(active):
+            raise DatasetContractError(f"{name} must use canonical ascending relation order")
+
+
+def _decode_hm_board(
+    perspective: Perspective, own_king_square: int, active_hm: Sequence[int]
+) -> dict[int, tuple[int, int]]:
+    """Reconstruct one absolute-color board from one perspective's HM rows.
+
+    Values are ``(absolute_color, piece_kind)`` where colors use WHITE=0 /
+    BLACK=1 and piece kinds use pawn..queen=0..4, king=5.  The two provider
+    perspectives must independently reconstruct the identical map.
+    """
+
+    orientation = make_joint_orientation(perspective, own_king_square)
+    board: dict[int, tuple[int, int]] = {}
+    color_counts = [0, 0]
+    relative_king_counts = [0, 0]
+    own_king_feature_square: Optional[int] = None
+    for index in active_hm:
+        if index // HM_ROWS_PER_BUCKET != orientation.king_bucket:
+            raise DatasetContractError(
+                f"{perspective.name} HM feature uses a bucket inconsistent with its own king"
+            )
+        local = index % HM_ROWS_PER_BUCKET
+        plane, oriented_square = divmod(local, 64)
+        own = plane == 10 or (plane < 10 and plane % 2 == 0)
+        opponent = plane == 11 or (plane < 10 and plane % 2 == 1)
+        if not own and not opponent:
+            raise DatasetContractError(f"{perspective.name} HM feature has an invalid piece plane")
+        is_king = plane >= 10
+        piece_kind = 5 if is_king else plane // 2
+        absolute_color = int(perspective) if own else 1 - int(perspective)
+        square = orientation.orient(oriented_square)
+        if square in board:
+            raise DatasetContractError(
+                f"{perspective.name} HM reconstructs more than one piece on square {square}"
+            )
+        board[square] = (absolute_color, piece_kind)
+        color_counts[absolute_color] += 1
+        if color_counts[absolute_color] > 16:
+            raise DatasetContractError(
+                f"{perspective.name} HM reconstructs more than 16 pieces for one color"
+            )
+        if is_king:
+            relative_king_counts[0 if own else 1] += 1
+            if own:
+                own_king_feature_square = square
+
+    if relative_king_counts != [1, 1]:
+        raise DatasetContractError(
+            f"{perspective.name} HM must contain exactly one own and one opponent king"
+        )
+    if own_king_feature_square != own_king_square:
+        raise DatasetContractError(
+            f"{perspective.name} own king square differs from its HM king feature"
+        )
+    return board
+
+
+def validate_batch(batch: AtomicV3Batch) -> AtomicV3Batch:
+    if not isinstance(batch, AtomicV3Batch):
+        raise DatasetContractError("AtomicNNUEV3 requires an AtomicV3Batch")
+    stm = batch.side_to_move_white
+    if stm.ndim != 2 or stm.shape[1] != 1 or stm.dtype != torch.float32:
+        raise DatasetContractError("side_to_move_white must be float32 [batch, 1]")
+    batch_size = int(stm.shape[0])
+    if batch_size == 0 or not torch.all((stm == 0.0) | (stm == 1.0)):
+        raise DatasetContractError("side_to_move_white must contain exact zero/one values")
+    if batch.piece_counts.shape != (batch_size,) or batch.piece_counts.dtype != torch.long:
+        raise DatasetContractError("piece_counts must be torch.long [batch]")
+    if batch.bucket_indices.shape != (batch_size,) or batch.bucket_indices.dtype != torch.long:
+        raise DatasetContractError("bucket_indices must be torch.long [batch]")
+    if batch.outcome.shape != (batch_size, 1) or batch.score.shape != (batch_size, 1):
+        raise DatasetContractError("outcome and score must have shape [batch, 1]")
+    if batch.outcome.dtype != torch.float32 or batch.score.dtype != torch.float32:
+        raise DatasetContractError("outcome and score must use float32")
+    if not torch.all(torch.isfinite(batch.outcome)) or not torch.all(torch.isfinite(batch.score)):
+        raise DatasetContractError("labels must be finite")
+    if not torch.all(
+        (batch.outcome == 0.0) | (batch.outcome == 0.5) | (batch.outcome == 1.0)
+    ):
+        raise DatasetContractError("outcome must be exactly one of 0, 0.5, or 1")
+    score64 = batch.score.to(torch.float64)
+    if not torch.all(batch.score == torch.trunc(batch.score)) or not torch.all(
+        (score64 >= -(1 << 31)) & (score64 <= (1 << 31) - 1)
+    ):
+        raise DatasetContractError("score must contain integer values in the signed int32 domain")
+
+    for row, count in enumerate(batch.piece_counts.tolist()):
+        try:
+            expected = network_bucket(count)
+        except (TypeError, ValueError) as error:
+            raise DatasetContractError(f"piece_counts[{row}] is outside [2, 32]") from error
+        if int(batch.bucket_indices[row]) != expected:
+            raise DatasetContractError("shared PSQT/dense bucket does not match piece count")
+
+    reconstructed: dict[Perspective, list[dict[int, tuple[int, int]]]] = {
+        Perspective.WHITE: [],
+        Perspective.BLACK: [],
+    }
+    for perspective, perspective_batch in (
+        (Perspective.WHITE, batch.white),
+        (Perspective.BLACK, batch.black),
+    ):
+        if not isinstance(perspective_batch, PerspectiveBatch):
+            raise DatasetContractError("perspective payload must be PerspectiveBatch")
+        kings = perspective_batch.own_king_squares
+        if kings.shape != (batch_size,) or kings.dtype != torch.long:
+            raise DatasetContractError("own_king_squares must be torch.long [batch]")
+        _validate_sparse_slice(
+            f"{perspective.name}.hm",
+            perspective_batch.hm,
+            batch_size=batch_size,
+            dimensions=SLICES[0].dimensions,
+            max_active=HM_MAX_ACTIVE,
+            require_active=True,
+            sorted_unique=False,
+        )
+        _validate_sparse_slice(
+            f"{perspective.name}.capture_pair",
+            perspective_batch.capture_pair,
+            batch_size=batch_size,
+            dimensions=SLICES[1].dimensions,
+            max_active=CAPTURE_PAIR_MAX_ACTIVE,
+            require_active=False,
+            sorted_unique=True,
+        )
+        _validate_sparse_slice(
+            f"{perspective.name}.king_blast_ep",
+            perspective_batch.king_blast_ep,
+            batch_size=batch_size,
+            dimensions=SLICES[2].dimensions,
+            max_active=KING_BLAST_EP_MAX_ACTIVE,
+            require_active=False,
+            sorted_unique=True,
+        )
+        _validate_sparse_slice(
+            f"{perspective.name}.blast_ring",
+            perspective_batch.blast_ring,
+            batch_size=batch_size,
+            dimensions=SLICES[3].dimensions,
+            max_active=BLAST_RING_MAX_ACTIVE,
+            require_active=False,
+            sorted_unique=True,
+        )
+        for row, king in enumerate(kings.tolist()):
+            try:
+                orientation = make_joint_orientation(perspective, king)
+            except (TypeError, ValueError) as error:
+                raise DatasetContractError(f"invalid {perspective.name} own king square") from error
+            active_hm = [index for index in perspective_batch.hm.indices[row].tolist() if index != -1]
+            if len(active_hm) != int(batch.piece_counts[row]):
+                raise DatasetContractError(
+                    f"{perspective.name} active HM count does not match piece_count"
+                )
+            reconstructed[perspective].append(
+                _decode_hm_board(perspective, king, active_hm)
+            )
+    for row in range(batch_size):
+        if reconstructed[Perspective.WHITE][row] != reconstructed[Perspective.BLACK][row]:
+            raise DatasetContractError(
+                "WHITE and BLACK HM perspectives do not reconstruct the same board"
+            )
+    return batch
+
+
+def _padded_slice(rows: Sequence[Sequence[int]]) -> SparseSliceBatch:
+    width = max(1, max((len(row) for row in rows), default=0))
+    indices = torch.full((len(rows), width), -1, dtype=torch.int32)
+    values = torch.zeros((len(rows), width), dtype=torch.float32)
+    for row_index, row in enumerate(rows):
+        if row:
+            indices[row_index, : len(row)] = torch.tensor(row, dtype=torch.int32)
+            values[row_index, : len(row)] = 1.0
+    return SparseSliceBatch(indices, values)
+
+
+def _perspective_from_fixture(samples: Sequence[Mapping[str, Any]], key: str) -> PerspectiveBatch:
+    payloads = [sample[key] for sample in samples]
+    return PerspectiveBatch(
+        own_king_squares=torch.tensor(
+            [payload["own_king_square"] for payload in payloads], dtype=torch.long
+        ),
+        hm=_padded_slice([payload["hm"] for payload in payloads]),
+        capture_pair=_padded_slice([payload["capture_pair"] for payload in payloads]),
+        king_blast_ep=_padded_slice([payload["king_blast_ep"] for payload in payloads]),
+        blast_ring=_padded_slice([payload["blast_ring"] for payload in payloads]),
+    )
+
+
+@dataclass(frozen=True)
+class CanonicalFixture:
+    campaign_sha256: str
+    collection_sha256: str
+    roles: Mapping[str, tuple[Mapping[str, Any], ...]]
+
+    def batch(self, role: Literal["train", "validation"]) -> AtomicV3Batch:
+        if role not in ("train", "validation"):
+            raise DatasetContractError("fixture role must be train or validation")
+        samples = self.roles[role]
+        for sample in samples:
+            if sample.get("side_to_move") not in ("WHITE", "BLACK"):
+                raise DatasetContractError("fixture side_to_move must be WHITE or BLACK")
+            if not _is_plain_int(sample.get("piece_count")):
+                raise DatasetContractError("fixture piece_count must be an integer")
+            outcome = sample.get("outcome")
+            if isinstance(outcome, bool) or not isinstance(outcome, (int, float)):
+                raise DatasetContractError("fixture outcome must be a numeric result enum")
+            if float(outcome) not in (0.0, 0.5, 1.0):
+                raise DatasetContractError("fixture outcome is outside the contractual domain")
+            score = sample.get("score")
+            if not _is_plain_int(score) or score < -(1 << 31) or score > (1 << 31) - 1:
+                raise DatasetContractError("fixture score must be a signed int32 integer")
+        batch = AtomicV3Batch(
+            side_to_move_white=torch.tensor(
+                [[1.0 if sample["side_to_move"] == "WHITE" else 0.0] for sample in samples],
+                dtype=torch.float32,
+            ),
+            piece_counts=torch.tensor([sample["piece_count"] for sample in samples], dtype=torch.long),
+            white=_perspective_from_fixture(samples, "white"),
+            black=_perspective_from_fixture(samples, "black"),
+            outcome=torch.tensor([[sample["outcome"]] for sample in samples], dtype=torch.float32),
+            score=torch.tensor([[sample["score"]] for sample in samples], dtype=torch.float32),
+            bucket_indices=torch.tensor(
+                [network_bucket(sample["piece_count"]) for sample in samples], dtype=torch.long
+            ),
+        )
+        return validate_batch(batch)
+
+
+# Updated only when the reviewed fixture bytes intentionally change.
+CANONICAL_FIXTURE_SHA256 = "d6a715d838f5dd029a793f5e62552afb34275f0310e720ff61514138eee47276"
+
+
+def load_canonical_fixture(
+    path: Optional[Union[str, Path]] = None,
+) -> CanonicalFixture:
+    if path is None:
+        path = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "atomic_v3" / "trainer-core-v1.json"
+    supplied_path = Path(path)
+    if supplied_path.is_symlink():
+        raise DatasetContractError("fixture symbolic links are forbidden")
+    fixture_path = supplied_path.resolve(strict=True)
+    raw = _read_regular_authenticated(
+        fixture_path, CANONICAL_FIXTURE_SHA256, maximum=1024 * 1024
+    )
+    try:
+        document = json.loads(raw.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys)
+    except DatasetContractError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise DatasetContractError(f"canonical trainer fixture is malformed: {error}") from error
+    if not isinstance(document, dict) or document.get("fixture_schema") != "atomic-v3-trainer-core-v1":
+        raise DatasetContractError("canonical trainer fixture schema mismatch")
+    if document.get("feature_schema_sha256") != FEATURE_SCHEMA_SHA256:
+        raise DatasetContractError("canonical trainer fixture feature schema mismatch")
+    roles = document.get("roles")
+    if not isinstance(roles, dict) or set(roles) != {"train", "validation"}:
+        raise DatasetContractError("canonical trainer fixture roles differ")
+    normalized: dict[str, tuple[Mapping[str, Any], ...]] = {}
+    ids: dict[str, set[str]] = {}
+    for role in ("train", "validation"):
+        samples = roles[role]
+        if not isinstance(samples, list) or not samples:
+            raise DatasetContractError(f"canonical {role} fixture is empty")
+        if not all(isinstance(sample, dict) for sample in samples):
+            raise DatasetContractError(f"canonical {role} sample is not an object")
+        role_ids = {sample.get("sample_id") for sample in samples}
+        if None in role_ids or len(role_ids) != len(samples):
+            raise DatasetContractError(f"canonical {role} sample IDs are not unique")
+        ids[role] = role_ids
+        normalized[role] = tuple(samples)
+    if ids["train"] & ids["validation"]:
+        raise DatasetContractError("canonical train and validation IDs overlap")
+    fixture = CanonicalFixture(
+        campaign_sha256=_require_sha256("fixture.campaign_sha256", document.get("campaign_sha256")),
+        collection_sha256=_require_sha256(
+            "fixture.collection_sha256", document.get("collection_sha256")
+        ),
+        roles=normalized,
+    )
+    fixture.batch("train")
+    fixture.batch("validation")
+    return fixture

--- a/atomic_v3/dense.py
+++ b/atomic_v3/dense.py
@@ -1,0 +1,156 @@
+"""Private byte-identical SFNNv15 dense tail for AtomicNNUEV3."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from .contract import LAYER_STACKS
+from .quantization import (
+    FC0_BIAS_SCALE,
+    FC0_WEIGHT_SCALE,
+    FC1_BIAS_SCALE,
+    FC1_WEIGHT_SCALE,
+    FC2_BIAS_SCALE,
+    FC2_WEIGHT_SCALE,
+    INT32_MAX,
+    INT32_MIN,
+    clip_hidden_activation,
+    fake_quantize_activation,
+    fake_quantize_integer,
+    fake_quantize_output,
+    fake_quantize_weight,
+    inward_float32_i32_bounds,
+)
+
+
+class StackedLinear(nn.Module):
+    def __init__(
+        self, inputs: int, outputs: int, count: int, weight_scale: float, bias_scale: float
+    ):
+        super().__init__()
+        self.inputs = inputs
+        self.outputs = outputs
+        self.count = count
+        self.weight_scale = weight_scale
+        self.bias_scale = bias_scale
+        self.linear = nn.Linear(inputs, outputs * count)
+        self._repeat_first_bucket()
+
+    @torch.no_grad()
+    def _repeat_first_bucket(self) -> None:
+        weight = self.linear.weight[: self.outputs]
+        bias = self.linear.bias[: self.outputs]
+        self.linear.weight.copy_(weight.repeat(self.count, 1))
+        self.linear.bias.copy_(bias.repeat(self.count))
+
+    def _merged_parameters(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.linear.weight, self.linear.bias
+
+    def forward(
+        self, value: torch.Tensor, bucket_indices: torch.Tensor, fake_quantize_weights: bool
+    ) -> torch.Tensor:
+        if value.ndim != 2 or bucket_indices.shape != (value.shape[0],):
+            raise ValueError("stacked linear requires [batch, inputs] and [batch] buckets")
+        if bucket_indices.dtype != torch.long:
+            raise TypeError("layer-stack indices must use torch.long")
+        if torch.any((bucket_indices < 0) | (bucket_indices >= self.count)):
+            raise ValueError("layer-stack index outside [0, 7]")
+        weight, bias = self._merged_parameters()
+        if fake_quantize_weights:
+            weight = fake_quantize_weight(weight, self.weight_scale)
+            bias = fake_quantize_integer_bias(bias, self.bias_scale)
+        broad = F.linear(value, weight, bias)
+        rows = broad.reshape(-1, self.outputs)
+        offsets = torch.arange(
+            0, bucket_indices.numel() * self.count, self.count, device=broad.device
+        )
+        return rows[bucket_indices.reshape(-1) + offsets]
+
+
+def fake_quantize_integer_bias(value: torch.Tensor, scale: float) -> torch.Tensor:
+    # Dense biases are signed i32.  Clamp to an inward float32 boundary before
+    # quantization: INT32_MAX / scale can otherwise round outward merely by
+    # storing the quantized parameter back in float32.
+    minimum, maximum = inward_float32_i32_bounds(scale)
+    exportable = value.clamp(minimum, maximum)
+    return fake_quantize_integer(
+        exportable, scale=scale, minimum=INT32_MIN, maximum=INT32_MAX
+    )
+
+
+class FactorizedStackedLinear(StackedLinear):
+    def __init__(
+        self, inputs: int, outputs: int, count: int, weight_scale: float, bias_scale: float
+    ):
+        super().__init__(inputs, outputs, count, weight_scale, bias_scale)
+        self.factorized_linear = nn.Linear(inputs, outputs)
+        with torch.no_grad():
+            self.factorized_linear.weight.zero_()
+            self.factorized_linear.bias.zero_()
+
+    def _merged_parameters(self) -> tuple[torch.Tensor, torch.Tensor]:
+        return (
+            self.linear.weight + self.factorized_linear.weight.repeat(self.count, 1),
+            self.linear.bias + self.factorized_linear.bias.repeat(self.count),
+        )
+
+
+class AtomicV3LayerStacks(nn.Module):
+    """Eight SFNNv15 stacks with the frozen squared paths and short skip."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc0 = FactorizedStackedLinear(
+            1024, 32, LAYER_STACKS, FC0_WEIGHT_SCALE, FC0_BIAS_SCALE
+        )
+        self.fc1 = StackedLinear(64, 32, LAYER_STACKS, FC1_WEIGHT_SCALE, FC1_BIAS_SCALE)
+        self.fc2 = StackedLinear(128, 1, LAYER_STACKS, FC2_WEIGHT_SCALE, FC2_BIAS_SCALE)
+        with torch.no_grad():
+            self.fc2.linear.bias.zero_()
+
+    def forward(
+        self,
+        value: torch.Tensor,
+        bucket_indices: torch.Tensor,
+        fake_quantize_activations: bool = True,
+        fake_quantize_weights: bool = True,
+    ) -> torch.Tensor:
+        if value.ndim != 2 or value.shape[1] != 1024:
+            raise ValueError("SFNNv15 layer stacks require [batch, 1024] input")
+        if bucket_indices.shape != (value.shape[0],):
+            raise ValueError("layer-stack indices must have shape [batch]")
+
+        fc0 = self.fc0(value, bucket_indices, fake_quantize_weights)
+        short_skip = fc0[:, -2:-1] - fc0[:, -1:]
+        fc0_squared = fc0.square()
+        fc0_linear = fc0
+        if fake_quantize_activations:
+            fc0_squared = fake_quantize_activation(fc0_squared)
+            fc0_linear = fake_quantize_activation(fc0_linear)
+        activated0 = clip_hidden_activation(torch.cat((fc0_squared, fc0_linear), dim=1))
+
+        fc1 = self.fc1(activated0, bucket_indices, fake_quantize_weights)
+        fc1_squared = fc1.square()
+        fc1_linear = fc1
+        if fake_quantize_activations:
+            fc1_squared = fake_quantize_activation(fc1_squared)
+            fc1_linear = fake_quantize_activation(fc1_linear)
+        activated1 = clip_hidden_activation(torch.cat((fc1_squared, fc1_linear), dim=1))
+
+        output = self.fc2(
+            torch.cat((activated0, activated1), dim=1),
+            bucket_indices,
+            fake_quantize_weights,
+        ) + short_skip
+        if fake_quantize_activations:
+            output = fake_quantize_output(output)
+        return output
+
+
+def pairwise_multiply(value: torch.Tensor) -> torch.Tensor:
+    if value.ndim != 2 or value.shape[1] != 2048:
+        raise ValueError("pairwise multiply requires [batch, 2048] input")
+    first_us, second_us, first_them, second_them = value.split(512, dim=1)
+    return torch.cat((first_us * second_us, first_them * second_them), dim=1)

--- a/atomic_v3/indices.py
+++ b/atomic_v3/indices.py
@@ -1,0 +1,212 @@
+"""Pure trainer-side index and signed-arithmetic oracles for AtomicNNUEV3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Union
+
+from .contract import (
+    BLAST_RING_DIMENSIONS,
+    CAPTURE_PAIR_DIMENSIONS,
+    CAPTURE_PAIR_EP_EDGES_PER_RELATION,
+    CAPTURE_PAIR_GEOMETRY_DIMENSIONS,
+    CAPTURE_PAIR_NORMAL_DIMENSIONS,
+    HM_KING_BUCKETS,
+    HM_PHYSICAL_ROWS_PER_BUCKET,
+    HM_ROWS_PER_BUCKET,
+    KING_BLAST_EP_DIMENSIONS,
+)
+
+
+class Perspective(IntEnum):
+    WHITE = 0
+    BLACK = 1
+
+
+class ActorRelation(IntEnum):
+    OWN = 0
+    OPP = 1
+
+
+class CollateralRelation(IntEnum):
+    OWN = 0
+    OPP = 1
+
+
+def _bounded_integer(name: str, value: int, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value < minimum or value > maximum:
+        raise ValueError(f"{name} outside [{minimum}, {maximum}]")
+    return value
+
+
+def _strict_enum(name: str, enum_type: type[IntEnum], value: Union[IntEnum, int]) -> IntEnum:
+    # ``bool`` is an ``int`` subclass, so IntEnum(True) silently aliases enum
+    # value 1 unless it is rejected before conversion.  Wire/provider enums are
+    # integer domains, never truth values.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer enum value")
+    try:
+        return enum_type(value)
+    except ValueError as error:
+        raise ValueError(f"{name} is outside the enum domain") from error
+
+
+@dataclass(frozen=True)
+class JointOrientation:
+    perspective: Perspective
+    own_king: int
+    oriented_own_king: int
+    vertical_xor: int
+    horizontal_xor: int
+    king_bucket: int
+
+    def orient(self, square: int) -> int:
+        return _bounded_integer("square", square, 0, 63) ^ self.vertical_xor ^ self.horizontal_xor
+
+
+def make_joint_orientation(
+    perspective: Union[Perspective, int], own_king: int
+) -> JointOrientation:
+    perspective = _strict_enum("perspective", Perspective, perspective)
+    own_king = _bounded_integer("own_king", own_king, 0, 63)
+    vertical = 56 if perspective is Perspective.BLACK else 0
+    pre_horizontal = own_king ^ vertical
+    horizontal = 7 if (pre_horizontal & 7) < 4 else 0
+    oriented = pre_horizontal ^ horizontal
+    rank_index, file_index = divmod(oriented, 8)
+    bucket = (7 - rank_index) * 4 + (7 - file_index)
+    assert 0 <= bucket < HM_KING_BUCKETS
+    return JointOrientation(perspective, own_king, oriented, vertical, horizontal, bucket)
+
+
+def network_bucket(piece_count: int) -> int:
+    piece_count = _bounded_integer("piece_count", piece_count, 2, 32)
+    return (piece_count - 1) // 4
+
+
+def hm_training_index(king_bucket: int, training_plane: int, oriented_square: int) -> int:
+    king_bucket = _bounded_integer("king_bucket", king_bucket, 0, 31)
+    training_plane = _bounded_integer("training_plane", training_plane, 0, 11)
+    oriented_square = _bounded_integer("oriented_square", oriented_square, 0, 63)
+    return king_bucket * HM_ROWS_PER_BUCKET + training_plane * 64 + oriented_square
+
+
+def hm_virtual_index(training_plane: int, oriented_square: int) -> int:
+    training_plane = _bounded_integer("training_plane", training_plane, 0, 11)
+    oriented_square = _bounded_integer("oriented_square", oriented_square, 0, 63)
+    return training_plane * 64 + oriented_square
+
+
+def hm_physical_index(king_bucket: int, physical_plane: int, oriented_square: int) -> int:
+    king_bucket = _bounded_integer("king_bucket", king_bucket, 0, 31)
+    physical_plane = _bounded_integer("physical_plane", physical_plane, 0, 10)
+    oriented_square = _bounded_integer("oriented_square", oriented_square, 0, 63)
+    return king_bucket * HM_PHYSICAL_ROWS_PER_BUCKET + physical_plane * 64 + oriented_square
+
+
+def hm_export_training_plane(physical_plane: int, oriented_square: int, oriented_own_king: int) -> int:
+    """Map the frozen 11-plane wire row back to its factorized 12-plane row."""
+
+    physical_plane = _bounded_integer("physical_plane", physical_plane, 0, 10)
+    oriented_square = _bounded_integer("oriented_square", oriented_square, 0, 63)
+    oriented_own_king = _bounded_integer("oriented_own_king", oriented_own_king, 0, 63)
+    if physical_plane < 10:
+        return physical_plane
+    return 10 if oriented_square == oriented_own_king else 11
+
+
+def hm_export_sources(
+    king_bucket: int, physical_plane: int, oriented_square: int, oriented_own_king: int
+) -> tuple[int, int]:
+    plane = hm_export_training_plane(physical_plane, oriented_square, oriented_own_king)
+    return (
+        hm_training_index(king_bucket, plane, oriented_square),
+        hm_virtual_index(plane, oriented_square),
+    )
+
+
+def capture_pair_normal_index(
+    actor_relation: Union[ActorRelation, int], edge: int, target: int
+) -> int:
+    actor_relation = _strict_enum("actor_relation", ActorRelation, actor_relation)
+    edge = _bounded_integer("edge", edge, 0, CAPTURE_PAIR_GEOMETRY_DIMENSIONS - 1)
+    target = _bounded_integer("target", target, 0, 5)
+    result = (int(actor_relation) * CAPTURE_PAIR_GEOMETRY_DIMENSIONS + edge) * 6 + target
+    assert 0 <= result < CAPTURE_PAIR_NORMAL_DIMENSIONS
+    return result
+
+
+def capture_pair_ep_index(
+    actor_relation: Union[ActorRelation, int], ep_ordinal: int
+) -> int:
+    actor_relation = _strict_enum("actor_relation", ActorRelation, actor_relation)
+    ep_ordinal = _bounded_integer(
+        "ep_ordinal", ep_ordinal, 0, CAPTURE_PAIR_EP_EDGES_PER_RELATION - 1
+    )
+    result = CAPTURE_PAIR_NORMAL_DIMENSIONS + int(actor_relation) * 14 + ep_ordinal
+    assert 0 <= result < CAPTURE_PAIR_DIMENSIONS
+    return result
+
+
+def king_blast_ep_index(
+    center: int, actor_relation: Union[ActorRelation, int], relation_class: int
+) -> int:
+    center = _bounded_integer("center", center, 0, 63)
+    actor_relation = _strict_enum("actor_relation", ActorRelation, actor_relation)
+    relation_class = _bounded_integer("relation_class", relation_class, 0, 17)
+    result = (center * 2 + int(actor_relation)) * 18 + relation_class
+    assert 0 <= result < KING_BLAST_EP_DIMENSIONS
+    return result
+
+
+def blast_ring_index(
+    center: int,
+    actor_relation: Union[ActorRelation, int],
+    collateral_relation: Union[CollateralRelation, int],
+    direction: int,
+    collateral_class: int,
+) -> int:
+    center = _bounded_integer("center", center, 0, 63)
+    actor_relation = _strict_enum("actor_relation", ActorRelation, actor_relation)
+    collateral_relation = _strict_enum(
+        "collateral_relation", CollateralRelation, collateral_relation
+    )
+    direction = _bounded_integer("direction", direction, 0, 7)
+    collateral_class = _bounded_integer("collateral_class", collateral_class, 0, 4)
+    result = (
+        ((((center * 2 + int(actor_relation)) * 2 + int(collateral_relation)) * 8 + direction) * 5)
+        + collateral_class
+    )
+    assert 0 <= result < BLAST_RING_DIMENSIONS
+    return result
+
+
+def trunc_div_toward_zero(numerator: int, denominator: int) -> int:
+    if isinstance(numerator, bool) or not isinstance(numerator, int):
+        raise TypeError("numerator must be an integer")
+    if isinstance(denominator, bool) or not isinstance(denominator, int):
+        raise TypeError("denominator must be an integer")
+    if denominator == 0:
+        raise ZeroDivisionError("division by zero")
+    magnitude = abs(numerator) // abs(denominator)
+    return -magnitude if (numerator < 0) != (denominator < 0) else magnitude
+
+
+def scale_raw_output(raw_output: int) -> int:
+    raw_output = _bounded_integer("raw_output", raw_output, -3_665_038_760, 3_665_038_759)
+    result = trunc_div_toward_zero(raw_output * 9_600, 16_384)
+    if result < -(1 << 31) or result > (1 << 31) - 1:
+        raise OverflowError("scaled output does not fit signed i32")
+    return result
+
+
+def psqt_perspective_difference(first: int, second: int) -> int:
+    for name, value in (("first", first), ("second", second)):
+        _bounded_integer(name, value, -(1 << 31), (1 << 31) - 1)
+    result = trunc_div_toward_zero(first - second, 2)
+    if result < -(1 << 31) or result > (1 << 31) - 1:
+        raise OverflowError("PSQT perspective difference does not fit signed i32")
+    return result

--- a/atomic_v3/model.py
+++ b/atomic_v3/model.py
@@ -40,6 +40,7 @@ from .quantization import (
     INT32_MIN,
     PSQT_EXPORT_MAX,
     PSQT_EXPORT_MIN,
+    PSQT_WEIGHT_SCALE,
     clip_feature_activation,
     fake_quantize_activation,
     fake_quantize_i16_feature,
@@ -47,6 +48,101 @@ from .quantization import (
     fake_quantize_psqt_output,
     fake_quantize_psqt_weight,
 )
+
+
+@torch.no_grad()
+def _clip_factorized_i32_sums_(
+    base: torch.Tensor,
+    expanded_factor: torch.Tensor,
+    *,
+    scale: float,
+    minimum: float,
+    maximum: float,
+    label: str,
+) -> None:
+    """Constrain persisted ``base + factor`` in both accumulation widths.
+
+    Computing ``maximum - factor`` in float32 is not sufficient.  When the two
+    operands have opposite signs, that subtraction can round the persisted
+    base outward; adding the operands again can then produce an i32 overflow.
+    Form the target in float64, write a coordinated float32 base, and correct
+    it with bounded ``nextafter`` steps until the *actual wire rounding* is in
+    range from both a float32 and float64 view of the persisted operands.
+    """
+
+    if base.dtype != torch.float32 or expanded_factor.dtype != torch.float32:
+        raise TypeError(f"Atomic V3 {label} factors must use float32 parameters")
+    if base.shape != expanded_factor.shape or base.device != expanded_factor.device:
+        raise ValueError(f"Atomic V3 {label} factor shapes/devices are inconsistent")
+    if not torch.all(torch.isfinite(base)) or not torch.all(torch.isfinite(expanded_factor)):
+        raise FloatingPointError(f"Atomic V3 {label} factor is non-finite")
+
+    target = (base.to(torch.float64) + expanded_factor.to(torch.float64)).clamp(
+        float(minimum), float(maximum)
+    )
+    base.copy_((target - expanded_factor.to(torch.float64)).to(base.dtype))
+
+    positive = base.new_full((), float("inf"))
+    negative = base.new_full((), float("-inf"))
+    correction_target = base + expanded_factor
+    for _ in range(4):
+        merged32 = base + expanded_factor
+        merged64 = base.to(torch.float64) + expanded_factor.to(torch.float64)
+        # Promote after the float32 arithmetic but before comparing with the
+        # asymmetric i32 endpoint.  Comparing INT32_MAX directly in float32
+        # rounds the threshold itself to 2**31 and masks the overflow.
+        integer32 = torch.round(merged32 * merged32.new_tensor(scale)).to(torch.float64)
+        integer32_wide = torch.round(merged32.to(torch.float64) * float(scale))
+        integer64 = torch.round(merged64 * float(scale))
+        too_low = (
+            (integer32 < INT32_MIN)
+            | (integer32_wide < INT32_MIN)
+            | (integer64 < INT32_MIN)
+        )
+        too_high = (
+            (integer32 > INT32_MAX)
+            | (integer32_wide > INT32_MAX)
+            | (integer64 > INT32_MAX)
+        )
+        # Correct in the coalesced value's ULP domain.  Moving the base itself
+        # is not bounded when cancellation makes the base much smaller than
+        # the factor: one base ULP can then be far too small to change the
+        # persisted sum.  Re-targeting one merged float32 ULP inward and
+        # solving for the base in float64 is bounded because |base| is at most
+        # twice the clamped coalesced/factor envelope.
+        correction_target = torch.where(
+            too_low,
+            torch.nextafter(correction_target, positive),
+            torch.where(
+                too_high,
+                torch.nextafter(correction_target, negative),
+                correction_target,
+            ),
+        )
+        corrected_base = (
+            correction_target.to(torch.float64) - expanded_factor.to(torch.float64)
+        ).to(base.dtype)
+        base.copy_(torch.where(too_low | too_high, corrected_base, base))
+
+    merged32 = base + expanded_factor
+    merged64 = base.to(torch.float64) + expanded_factor.to(torch.float64)
+    integer32 = torch.round(merged32 * merged32.new_tensor(scale)).to(torch.float64)
+    integer32_wide = torch.round(merged32.to(torch.float64) * float(scale))
+    integer64 = torch.round(merged64 * float(scale))
+    valid = (
+        torch.isfinite(merged32)
+        & torch.isfinite(merged64)
+        & (integer32 >= INT32_MIN)
+        & (integer32 <= INT32_MAX)
+        & (integer32_wide >= INT32_MIN)
+        & (integer32_wide <= INT32_MAX)
+        & (integer64 >= INT32_MIN)
+        & (integer64 <= INT32_MAX)
+    )
+    if not torch.all(valid):
+        raise FloatingPointError(
+            f"Atomic V3 {label} could not be made signed-i32 exportable"
+        )
 
 
 @torch.no_grad()
@@ -59,48 +155,19 @@ def _clip_factorized_i32_biases_(
     minimum: float,
     maximum: float,
 ) -> None:
-    """Constrain every persisted ``base + factor`` in both accumulation widths.
+    """Constrain every persisted factorized dense bias."""
 
-    Computing the clamp endpoint in float32 is not sufficient here.  Opposite
-    signs can make float32 addition round outward even though the exact sum is
-    safe, while float64 addition can expose an unsafe half-ulp hidden by the
-    float32 sum.  Form the target in float64, saturate it to the inward wire
-    interval, then cast the coordinated base back to its parameter dtype.  A
-    bounded nextafter correction verifies the actual persisted operands in
-    both widths before returning.
-    """
-
-    if base.dtype != torch.float32 or factor.dtype != torch.float32:
-        raise TypeError("Atomic V3 factorized dense biases must use float32 parameters")
     if base.ndim != 1 or factor.ndim != 1 or base.numel() != factor.numel() * count:
         raise ValueError("Atomic V3 factorized dense bias shapes are inconsistent")
-
     factor.clamp_(minimum, maximum)
-    expanded = factor.repeat(count)
-    target = (base.to(torch.float64) + expanded.to(torch.float64)).clamp(
-        float(minimum), float(maximum)
+    _clip_factorized_i32_sums_(
+        base,
+        factor.repeat(count),
+        scale=scale,
+        minimum=minimum,
+        maximum=maximum,
+        label="FC0 bias",
     )
-    base.copy_((target - expanded.to(torch.float64)).to(base.dtype))
-
-    positive = base.new_full((), float("inf"))
-    negative = base.new_full((), float("-inf"))
-    for _ in range(4):
-        merged32 = base + expanded
-        merged64 = base.to(torch.float64) + expanded.to(torch.float64)
-        # Promote after the float32 arithmetic but before comparing with the
-        # asymmetric i32 endpoint.  Comparing INT32_MAX directly in float32
-        # rounds the threshold itself to 2**31 and masks the overflow.
-        integer32 = torch.round(merged32 * merged32.new_tensor(scale)).to(torch.float64)
-        integer64 = torch.round(merged64 * float(scale))
-        too_low = (integer32 < INT32_MIN) | (integer64 < INT32_MIN)
-        too_high = (integer32 > INT32_MAX) | (integer64 > INT32_MAX)
-        if not torch.any(too_low | too_high):
-            return
-        lower = torch.nextafter(base, positive)
-        upper = torch.nextafter(base, negative)
-        base.copy_(torch.where(too_low, lower, torch.where(too_high, upper, base)))
-
-    raise FloatingPointError("Atomic V3 FC0 bias could not be made signed-i32 exportable")
 
 
 def _sparse_sum(
@@ -206,6 +273,12 @@ class AtomicV3FeatureTransformer(nn.Module):
         i8_min, i8_max = -128.0 / FT_ONE, 127.0 / FT_ONE
         psqt_min = PSQT_EXPORT_MIN
         psqt_max = PSQT_EXPORT_MAX
+        hm_psqt_base = self.hm_bucket_weight[:, ACCUMULATOR_DIMENSIONS:]
+        hm_psqt_factor = self.hm_virtual_weight[:, ACCUMULATOR_DIMENSIONS:]
+        if not torch.all(torch.isfinite(hm_psqt_base)) or not torch.all(
+            torch.isfinite(hm_psqt_factor)
+        ):
+            raise FloatingPointError("Atomic V3 HM PSQT factor is non-finite")
         self.bias.clamp_(i16_min, i16_max)
         self.capture_pair_weight.clamp_(i8_min, i8_max)
         self.king_blast_ep_weight.clamp_(i16_min, i16_max)
@@ -216,8 +289,12 @@ class AtomicV3FeatureTransformer(nn.Module):
         # production-size tensor.
         self.hm_virtual_weight[:, :ACCUMULATOR_DIMENSIONS].clamp_(i16_min, i16_max)
         self.hm_virtual_weight[:, ACCUMULATOR_DIMENSIONS:].clamp_(psqt_min, psqt_max)
-        for bucket in range(32):
-            begin, end = bucket * HM_VIRTUAL_DIMENSIONS, (bucket + 1) * HM_VIRTUAL_DIMENSIONS
+        if self.hm_bucket_weight.shape[0] % self.hm_virtual_weight.shape[0] != 0:
+            raise ValueError("Atomic V3 HM factor shapes are inconsistent")
+        factor_rows = self.hm_virtual_weight.shape[0]
+        factor_count = self.hm_bucket_weight.shape[0] // factor_rows
+        for bucket in range(factor_count):
+            begin, end = bucket * factor_rows, (bucket + 1) * factor_rows
             base = self.hm_bucket_weight[begin:end]
             virtual = self.hm_virtual_weight
             base_main = base[:, :ACCUMULATOR_DIMENSIONS]
@@ -228,14 +305,14 @@ class AtomicV3FeatureTransformer(nn.Module):
                     base_main.new_tensor(i16_min) - virtual_main,
                 )
             )
-            base_psqt = base[:, ACCUMULATOR_DIMENSIONS:]
-            virtual_psqt = virtual[:, ACCUMULATOR_DIMENSIONS:]
-            base_psqt.copy_(
-                torch.maximum(
-                    torch.minimum(base_psqt, base_psqt.new_tensor(psqt_max) - virtual_psqt),
-                    base_psqt.new_tensor(psqt_min) - virtual_psqt,
-                )
-            )
+        _clip_factorized_i32_sums_(
+            hm_psqt_base,
+            hm_psqt_factor.repeat(factor_count, 1),
+            scale=PSQT_WEIGHT_SCALE,
+            minimum=psqt_min,
+            maximum=psqt_max,
+            label="HM PSQT weight",
+        )
 
 
 class AtomicNNUEV3(nn.Module):

--- a/atomic_v3/model.py
+++ b/atomic_v3/model.py
@@ -1,0 +1,333 @@
+"""Isolated mixed-slice AtomicNNUEV3 training graph."""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from .contract import (
+    ACCUMULATOR_DIMENSIONS,
+    BACKEND_NAME,
+    BLAST_RING_DIMENSIONS,
+    CAPTURE_PAIR_DIMENSIONS,
+    FEATURE_NAME,
+    HM_OUTPUT_DIMENSIONS,
+    HM_TRAINING_DIMENSIONS,
+    HM_VIRTUAL_DIMENSIONS,
+    KING_BLAST_EP_DIMENSIONS,
+    LAYER_STACKS,
+    PSQT_BUCKETS,
+)
+from .dataset import AtomicV3Batch, SparseSliceBatch, validate_batch
+from .dense import AtomicV3LayerStacks, pairwise_multiply
+from .quantization import (
+    FC0_BIAS_SCALE,
+    FC0_BIAS_EXPORT_MAX,
+    FC0_BIAS_EXPORT_MIN,
+    FC0_WEIGHT_SCALE,
+    FC1_BIAS_EXPORT_MAX,
+    FC1_BIAS_EXPORT_MIN,
+    FC1_WEIGHT_SCALE,
+    FC2_BIAS_EXPORT_MAX,
+    FC2_BIAS_EXPORT_MIN,
+    FC2_WEIGHT_SCALE,
+    FT_ONE,
+    INT32_MAX,
+    INT32_MIN,
+    PSQT_EXPORT_MAX,
+    PSQT_EXPORT_MIN,
+    clip_feature_activation,
+    fake_quantize_activation,
+    fake_quantize_i16_feature,
+    fake_quantize_i8_feature,
+    fake_quantize_psqt_output,
+    fake_quantize_psqt_weight,
+)
+
+
+@torch.no_grad()
+def _clip_factorized_i32_biases_(
+    base: torch.Tensor,
+    factor: torch.Tensor,
+    *,
+    count: int,
+    scale: float,
+    minimum: float,
+    maximum: float,
+) -> None:
+    """Constrain every persisted ``base + factor`` in both accumulation widths.
+
+    Computing the clamp endpoint in float32 is not sufficient here.  Opposite
+    signs can make float32 addition round outward even though the exact sum is
+    safe, while float64 addition can expose an unsafe half-ulp hidden by the
+    float32 sum.  Form the target in float64, saturate it to the inward wire
+    interval, then cast the coordinated base back to its parameter dtype.  A
+    bounded nextafter correction verifies the actual persisted operands in
+    both widths before returning.
+    """
+
+    if base.dtype != torch.float32 or factor.dtype != torch.float32:
+        raise TypeError("Atomic V3 factorized dense biases must use float32 parameters")
+    if base.ndim != 1 or factor.ndim != 1 or base.numel() != factor.numel() * count:
+        raise ValueError("Atomic V3 factorized dense bias shapes are inconsistent")
+
+    factor.clamp_(minimum, maximum)
+    expanded = factor.repeat(count)
+    target = (base.to(torch.float64) + expanded.to(torch.float64)).clamp(
+        float(minimum), float(maximum)
+    )
+    base.copy_((target - expanded.to(torch.float64)).to(base.dtype))
+
+    positive = base.new_full((), float("inf"))
+    negative = base.new_full((), float("-inf"))
+    for _ in range(4):
+        merged32 = base + expanded
+        merged64 = base.to(torch.float64) + expanded.to(torch.float64)
+        # Promote after the float32 arithmetic but before comparing with the
+        # asymmetric i32 endpoint.  Comparing INT32_MAX directly in float32
+        # rounds the threshold itself to 2**31 and masks the overflow.
+        integer32 = torch.round(merged32 * merged32.new_tensor(scale)).to(torch.float64)
+        integer64 = torch.round(merged64 * float(scale))
+        too_low = (integer32 < INT32_MIN) | (integer64 < INT32_MIN)
+        too_high = (integer32 > INT32_MAX) | (integer64 > INT32_MAX)
+        if not torch.any(too_low | too_high):
+            return
+        lower = torch.nextafter(base, positive)
+        upper = torch.nextafter(base, negative)
+        base.copy_(torch.where(too_low, lower, torch.where(too_high, upper, base)))
+
+    raise FloatingPointError("Atomic V3 FC0 bias could not be made signed-i32 exportable")
+
+
+def _sparse_sum(
+    features: SparseSliceBatch,
+    weight: torch.Tensor,
+    quantize: Optional[Callable[[torch.Tensor], torch.Tensor]],
+) -> torch.Tensor:
+    indices, values = features.indices, features.values
+    valid = indices != -1
+    safe = indices.clamp_min(0).to(torch.long)
+    # Quantize after gathering.  Besides avoiding a dense fake-quantized copy,
+    # this preserves sparse gradients for the 77,900-row production tables.
+    rows = F.embedding(safe, weight, sparse=True)
+    if quantize is not None:
+        rows = quantize(rows)
+    scales = torch.where(valid, values, torch.zeros_like(values)).unsqueeze(-1)
+    return (rows * scales).sum(dim=1)
+
+
+class AtomicV3FeatureTransformer(nn.Module):
+    """Four frozen slices; only HM owns factor rows and PSQT columns."""
+
+    def __init__(self, initialize: bool = True):
+        super().__init__()
+        self.bias = nn.Parameter(torch.empty(ACCUMULATOR_DIMENSIONS, dtype=torch.float32))
+        self.hm_bucket_weight = nn.Parameter(
+            torch.empty(HM_TRAINING_DIMENSIONS, HM_OUTPUT_DIMENSIONS, dtype=torch.float32)
+        )
+        self.hm_virtual_weight = nn.Parameter(
+            torch.empty(HM_VIRTUAL_DIMENSIONS, HM_OUTPUT_DIMENSIONS, dtype=torch.float32)
+        )
+        self.capture_pair_weight = nn.Parameter(
+            torch.empty(CAPTURE_PAIR_DIMENSIONS, ACCUMULATOR_DIMENSIONS, dtype=torch.float32)
+        )
+        self.king_blast_ep_weight = nn.Parameter(
+            torch.empty(KING_BLAST_EP_DIMENSIONS, ACCUMULATOR_DIMENSIONS, dtype=torch.float32)
+        )
+        self.blast_ring_weight = nn.Parameter(
+            torch.empty(BLAST_RING_DIMENSIONS, ACCUMULATOR_DIMENSIONS, dtype=torch.float32)
+        )
+        self.reset_parameters(initialize)
+
+    @torch.no_grad()
+    def reset_parameters(self, initialize: bool = True) -> None:
+        if initialize:
+            bound = math.sqrt(1.0 / (HM_TRAINING_DIMENSIONS + HM_VIRTUAL_DIMENSIONS))
+            self.hm_bucket_weight.uniform_(-bound, bound)
+            # Begin with an unfactorized model; the shared factor learns only
+            # signal supported across king buckets.
+            self.hm_virtual_weight.zero_()
+            self.bias.uniform_(-bound, bound)
+            self.capture_pair_weight.zero_()
+            self.king_blast_ep_weight.zero_()
+            self.blast_ring_weight.zero_()
+        else:
+            for parameter in self.parameters():
+                parameter.zero_()
+        # V3 relations have no hidden zero-initialized PSQT parameters.  HM's
+        # real PSQT columns start neutral.
+        self.hm_bucket_weight[:, ACCUMULATOR_DIMENSIONS:].zero_()
+        self.hm_virtual_weight[:, ACCUMULATOR_DIMENSIONS:].zero_()
+
+    def _hm_sum(self, features: SparseSliceBatch, fake_quantize_weights: bool) -> torch.Tensor:
+        safe = features.indices.clamp_min(0).to(torch.long)
+        valid = features.indices != -1
+        bucket_rows = F.embedding(safe, self.hm_bucket_weight, sparse=True)
+        virtual_rows = F.embedding(
+            torch.remainder(safe, HM_VIRTUAL_DIMENSIONS), self.hm_virtual_weight, sparse=True
+        )
+        coalesced = bucket_rows + virtual_rows
+        if fake_quantize_weights:
+            main = fake_quantize_i16_feature(coalesced[..., :ACCUMULATOR_DIMENSIONS])
+            psqt = fake_quantize_psqt_weight(coalesced[..., ACCUMULATOR_DIMENSIONS:])
+            coalesced = torch.cat((main, psqt), dim=-1)
+        scales = torch.where(valid, features.values, torch.zeros_like(features.values)).unsqueeze(-1)
+        return (coalesced * scales).sum(dim=1)
+
+    def forward(self, perspective, fake_quantize_weights: bool) -> tuple[torch.Tensor, torch.Tensor]:
+        hm = self._hm_sum(perspective.hm, fake_quantize_weights)
+        main, psqt = hm.split((ACCUMULATOR_DIMENSIONS, PSQT_BUCKETS), dim=1)
+        bias = fake_quantize_i16_feature(self.bias) if fake_quantize_weights else self.bias
+        main = main + bias
+        main = main + _sparse_sum(
+            perspective.capture_pair,
+            self.capture_pair_weight,
+            fake_quantize_i8_feature if fake_quantize_weights else None,
+        )
+        main = main + _sparse_sum(
+            perspective.king_blast_ep,
+            self.king_blast_ep_weight,
+            fake_quantize_i16_feature if fake_quantize_weights else None,
+        )
+        main = main + _sparse_sum(
+            perspective.blast_ring,
+            self.blast_ring_weight,
+            fake_quantize_i8_feature if fake_quantize_weights else None,
+        )
+        return main, psqt
+
+    @torch.no_grad()
+    def clip_weights(self) -> None:
+        i16_min, i16_max = -32768.0 / FT_ONE, 32767.0 / FT_ONE
+        i8_min, i8_max = -128.0 / FT_ONE, 127.0 / FT_ONE
+        psqt_min = PSQT_EXPORT_MIN
+        psqt_max = PSQT_EXPORT_MAX
+        self.bias.clamp_(i16_min, i16_max)
+        self.capture_pair_weight.clamp_(i8_min, i8_max)
+        self.king_blast_ep_weight.clamp_(i16_min, i16_max)
+        self.blast_ring_weight.clamp_(i8_min, i8_max)
+
+        # The wire stores bucket+virtual, so clipping either factor alone is
+        # insufficient.  Process one king bucket at a time to avoid a second
+        # production-size tensor.
+        self.hm_virtual_weight[:, :ACCUMULATOR_DIMENSIONS].clamp_(i16_min, i16_max)
+        self.hm_virtual_weight[:, ACCUMULATOR_DIMENSIONS:].clamp_(psqt_min, psqt_max)
+        for bucket in range(32):
+            begin, end = bucket * HM_VIRTUAL_DIMENSIONS, (bucket + 1) * HM_VIRTUAL_DIMENSIONS
+            base = self.hm_bucket_weight[begin:end]
+            virtual = self.hm_virtual_weight
+            base_main = base[:, :ACCUMULATOR_DIMENSIONS]
+            virtual_main = virtual[:, :ACCUMULATOR_DIMENSIONS]
+            base_main.copy_(
+                torch.maximum(
+                    torch.minimum(base_main, base_main.new_tensor(i16_max) - virtual_main),
+                    base_main.new_tensor(i16_min) - virtual_main,
+                )
+            )
+            base_psqt = base[:, ACCUMULATOR_DIMENSIONS:]
+            virtual_psqt = virtual[:, ACCUMULATOR_DIMENSIONS:]
+            base_psqt.copy_(
+                torch.maximum(
+                    torch.minimum(base_psqt, base_psqt.new_tensor(psqt_max) - virtual_psqt),
+                    base_psqt.new_tensor(psqt_min) - virtual_psqt,
+                )
+            )
+
+
+class AtomicNNUEV3(nn.Module):
+    backend_name = BACKEND_NAME
+    feature_name = FEATURE_NAME
+    accumulator_dimensions = ACCUMULATOR_DIMENSIONS
+    psqt_buckets = PSQT_BUCKETS
+    layer_stacks = LAYER_STACKS
+
+    def __init__(self, initialize: bool = True):
+        super().__init__()
+        self.feature_transformer = AtomicV3FeatureTransformer(initialize=initialize)
+        self.network = AtomicV3LayerStacks()
+
+    @torch.no_grad()
+    def clip_weights(self) -> None:
+        self.feature_transformer.clip_weights()
+        fc0_limit = 127.0 / FC0_WEIGHT_SCALE
+        fc0_factor = self.network.fc0.factorized_linear.weight
+        fc0_factor.clamp_(-fc0_limit, fc0_limit)
+        virtual = fc0_factor.repeat(LAYER_STACKS, 1)
+        base = self.network.fc0.linear.weight
+        base.copy_(
+            torch.maximum(
+                torch.minimum(base, base.new_full((), fc0_limit) - virtual),
+                base.new_full((), -fc0_limit) - virtual,
+            )
+        )
+        self.network.fc1.linear.weight.clamp_(
+            -127.0 / FC1_WEIGHT_SCALE, 127.0 / FC1_WEIGHT_SCALE
+        )
+        self.network.fc2.linear.weight.clamp_(
+            -127.0 / FC2_WEIGHT_SCALE, 127.0 / FC2_WEIGHT_SCALE
+        )
+
+        # The dense wire stores signed-i32 biases.  FC0 is factorized during
+        # training but serialized as base+factor, so constrain the coalesced
+        # value rather than merely clipping each factor independently.
+        dense_biases = (
+            ("FC0 base", self.network.fc0.linear.bias),
+            ("FC0 factor", self.network.fc0.factorized_linear.bias),
+            ("FC1", self.network.fc1.linear.bias),
+            ("FC2", self.network.fc2.linear.bias),
+        )
+        for name, bias in dense_biases:
+            if not torch.all(torch.isfinite(bias)):
+                raise FloatingPointError(f"Atomic V3 {name} bias is non-finite")
+
+        _clip_factorized_i32_biases_(
+            self.network.fc0.linear.bias,
+            self.network.fc0.factorized_linear.bias,
+            count=LAYER_STACKS,
+            scale=FC0_BIAS_SCALE,
+            minimum=FC0_BIAS_EXPORT_MIN,
+            maximum=FC0_BIAS_EXPORT_MAX,
+        )
+        self.network.fc1.linear.bias.clamp_(FC1_BIAS_EXPORT_MIN, FC1_BIAS_EXPORT_MAX)
+        self.network.fc2.linear.bias.clamp_(FC2_BIAS_EXPORT_MIN, FC2_BIAS_EXPORT_MAX)
+
+    def forward(
+        self,
+        batch: AtomicV3Batch,
+        *,
+        fake_quantize_activations: bool = True,
+        fake_quantize_weights: bool = True,
+        validate: bool = True,
+    ) -> torch.Tensor:
+        if validate:
+            validate_batch(batch)
+        white_main, white_psqt = self.feature_transformer.forward(
+            batch.white, fake_quantize_weights
+        )
+        black_main, black_psqt = self.feature_transformer.forward(
+            batch.black, fake_quantize_weights
+        )
+        white_bucket = white_psqt.gather(1, batch.bucket_indices.reshape(-1, 1))
+        black_bucket = black_psqt.gather(1, batch.bucket_indices.reshape(-1, 1))
+        us = batch.side_to_move_white
+        them = 1.0 - us
+        side_ordered = us * torch.cat((white_main, black_main), dim=1) + them * torch.cat(
+            (black_main, white_main), dim=1
+        )
+        transformed = pairwise_multiply(clip_feature_activation(side_ordered))
+        if fake_quantize_activations:
+            transformed = fake_quantize_activation(transformed)
+        stm_psqt_difference = us * (white_bucket - black_bucket) + them * (
+            black_bucket - white_bucket
+        )
+        positional = fake_quantize_psqt_output(stm_psqt_difference * 0.5)
+        return self.network(
+            transformed,
+            batch.bucket_indices,
+            fake_quantize_activations,
+            fake_quantize_weights,
+        ) + positional

--- a/atomic_v3/quantization.py
+++ b/atomic_v3/quantization.py
@@ -1,0 +1,141 @@
+"""AtomicNNUEV3 mixed feature and byte-identical SFNNv15 quantization."""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+
+import torch
+
+
+FT_ONE = 256.0
+FT_MAX = 255.0
+HIDDEN_ONE = 128.0
+HIDDEN_MAX = 127.0
+NNUE_TO_SCORE = 600.0
+OUTPUT_SCALE = 16.0
+
+FC0_WEIGHT_SCALE = 128.0
+FC1_WEIGHT_SCALE = 64.0
+FC2_WEIGHT_SCALE = 128.0
+FC0_BIAS_SCALE = FC0_WEIGHT_SCALE * HIDDEN_ONE
+FC1_BIAS_SCALE = FC1_WEIGHT_SCALE * HIDDEN_ONE
+FC2_BIAS_SCALE = FC2_WEIGHT_SCALE * HIDDEN_ONE
+PSQT_WEIGHT_SCALE = NNUE_TO_SCORE * OUTPUT_SCALE
+INT32_MIN = -(1 << 31)
+INT32_MAX = (1 << 31) - 1
+
+
+@lru_cache(maxsize=None)
+def inward_float32_i32_bounds(scale: float) -> tuple[float, float]:
+    """Return float32 parameter bounds that remain i32-safe when exported.
+
+    ``INT32_MAX / scale`` commonly rounds outward when stored as float32.  Move
+    each endpoint toward the interval until multiplication and rounding in
+    either float32 or float64 stays in the signed-i32 domain.
+    """
+
+    if (
+        not isinstance(scale, (int, float))
+        or isinstance(scale, bool)
+        or not math.isfinite(float(scale))
+        or scale <= 0
+    ):
+        raise ValueError("i32 export scale must be positive")
+    lower = torch.tensor(INT32_MIN / float(scale), dtype=torch.float32)
+    upper = torch.tensor(INT32_MAX / float(scale), dtype=torch.float32)
+
+    def exportable(value: torch.Tensor) -> bool:
+        integers = (
+            torch.round(value * value.new_tensor(scale)).item(),
+            torch.round(value.to(torch.float64) * float(scale)).item(),
+        )
+        return all(INT32_MIN <= integer <= INT32_MAX for integer in integers)
+
+    positive = lower.new_tensor(float("inf"))
+    negative = lower.new_tensor(float("-inf"))
+    while not exportable(lower):
+        lower = torch.nextafter(lower, positive)
+    while not exportable(upper):
+        upper = torch.nextafter(upper, negative)
+    return float(lower.item()), float(upper.item())
+
+
+FC0_BIAS_EXPORT_MIN, FC0_BIAS_EXPORT_MAX = inward_float32_i32_bounds(FC0_BIAS_SCALE)
+FC1_BIAS_EXPORT_MIN, FC1_BIAS_EXPORT_MAX = inward_float32_i32_bounds(FC1_BIAS_SCALE)
+FC2_BIAS_EXPORT_MIN, FC2_BIAS_EXPORT_MAX = inward_float32_i32_bounds(FC2_BIAS_SCALE)
+# Float32 cannot represent ``INT32_MAX / 9600`` without rounding out of the
+# signed-i32 domain.  These are the adjacent inward float32 values, used at the
+# persistent parameter boundary so a later exporter remains safe whether it
+# multiplies in float32 or float64.
+PSQT_EXPORT_MIN = -223696.203125
+PSQT_EXPORT_MAX = 223696.203125
+
+
+def fake_quantize_integer(
+    value: torch.Tensor, *, scale: float, minimum: int, maximum: int
+) -> torch.Tensor:
+    if scale <= 0:
+        raise ValueError("quantization scale must be positive")
+    if minimum >= maximum:
+        raise ValueError("quantization integer interval is empty")
+    # Promote the integer-domain clamp: near i32 limits a float32 clamp bound
+    # would itself round INT32_MAX to 2**31.
+    hard = (
+        value.to(torch.float64)
+        .mul(scale)
+        .round()
+        .clamp(minimum, maximum)
+        .div(scale)
+        .to(value.dtype)
+        .detach()
+    )
+    return hard + (value - value.detach())
+
+
+def fake_quantize_i16_feature(value: torch.Tensor) -> torch.Tensor:
+    return fake_quantize_integer(value, scale=FT_ONE, minimum=-32768, maximum=32767)
+
+
+def fake_quantize_i8_feature(value: torch.Tensor) -> torch.Tensor:
+    return fake_quantize_integer(value, scale=FT_ONE, minimum=-128, maximum=127)
+
+
+def fake_quantize_psqt_weight(value: torch.Tensor) -> torch.Tensor:
+    exportable = value.clamp(PSQT_EXPORT_MIN, PSQT_EXPORT_MAX)
+    return fake_quantize_integer(
+        exportable, scale=PSQT_WEIGHT_SCALE, minimum=-(1 << 31), maximum=(1 << 31) - 1
+    )
+
+
+def fake_quantize_weight(value: torch.Tensor, scale: float) -> torch.Tensor:
+    return fake_quantize_integer(value, scale=scale, minimum=-127, maximum=127)
+
+
+def fake_quantize_activation(value: torch.Tensor, scale: float = HIDDEN_ONE) -> torch.Tensor:
+    hard = value.mul(scale).add(1e-5).floor().div(scale).detach()
+    return hard + (value - value.detach())
+
+
+def clip_feature_activation(value: torch.Tensor) -> torch.Tensor:
+    return value.clamp(0.0, FT_MAX / FT_ONE)
+
+
+def clip_hidden_activation(value: torch.Tensor) -> torch.Tensor:
+    return value.clamp(0.0, HIDDEN_MAX / HIDDEN_ONE)
+
+
+def fake_quantize_output(value: torch.Tensor) -> torch.Tensor:
+    multiplier = int(NNUE_TO_SCORE * OUTPUT_SCALE)
+    denominator = int(HIDDEN_ONE * FC2_WEIGHT_SCALE * 2.0)
+    integer_value = torch.round(value * denominator).to(torch.int64)
+    quantized = torch.div(integer_value * multiplier, denominator, rounding_mode="trunc")
+    hard = quantized.to(value.dtype) / float(multiplier)
+    return hard.detach() + (value - value.detach())
+
+
+def fake_quantize_psqt_output(value: torch.Tensor) -> torch.Tensor:
+    twice_raw = torch.round(value * (2.0 * PSQT_WEIGHT_SCALE)).to(torch.int64)
+    raw = torch.div(twice_raw, 2, rounding_mode="trunc")
+    hard = raw.to(value.dtype) / PSQT_WEIGHT_SCALE
+    return hard.detach() + (value - value.detach())

--- a/atomic_v3/training.py
+++ b/atomic_v3/training.py
@@ -1,0 +1,208 @@
+"""Deterministic core loss and CPU fixture step for AtomicNNUEV3.
+
+The first real optimizer/schedule is intentionally not frozen here.  H9.3l-j
+uses zero-state SGD because it supports the transformer's sparse row gradients
+without allocating production-sized Adam moments; the controlled training
+configuration belongs to the later parameterization milestone.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import math
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+
+from .dataset import AtomicV3Batch, load_canonical_fixture, validate_batch
+from .model import AtomicNNUEV3
+
+
+@dataclass(frozen=True)
+class OneStepResult:
+    train_loss_before: float
+    train_loss_after: float
+    validation_loss_before: float
+    validation_loss_after: float
+    parameter_sha256: str
+
+
+def atomic_loss(
+    prediction: torch.Tensor,
+    outcome: torch.Tensor,
+    score: torch.Tensor,
+    *,
+    lambda_: float = 1.0,
+    score_input_scale: float = 410.0,
+    score_output_scale: float = 361.0,
+) -> torch.Tensor:
+    if prediction.shape != outcome.shape or score.shape != prediction.shape:
+        raise ValueError("prediction, outcome and score must have equal shape")
+    if not 0.0 <= lambda_ <= 1.0:
+        raise ValueError("lambda_ must be in [0, 1]")
+    if score_input_scale <= 0 or score_output_scale <= 0:
+        raise ValueError("score scales must be positive")
+    predicted_probability = (prediction * 600.0 / score_output_scale).sigmoid()
+    evaluation_probability = (score / score_input_scale).sigmoid()
+    evaluation_loss = (evaluation_probability - predicted_probability).square().mean()
+    result_loss = (predicted_probability - outcome).square().mean()
+    return lambda_ * evaluation_loss + (1.0 - lambda_) * result_loss
+
+
+def create_core_optimizer(
+    model: AtomicNNUEV3, learning_rate: float = 1.0e-3
+) -> torch.optim.Optimizer:
+    if not isinstance(model, AtomicNNUEV3):
+        raise TypeError("Atomic V3 optimizer accepts only AtomicNNUEV3")
+    if isinstance(learning_rate, bool) or not isinstance(learning_rate, (int, float)):
+        raise TypeError("learning_rate must be a real number")
+    learning_rate = float(learning_rate)
+    if not math.isfinite(learning_rate) or learning_rate <= 0:
+        raise ValueError("learning_rate must be finite and positive")
+    return torch.optim.SGD(
+        model.parameters(), lr=learning_rate, momentum=0.0, weight_decay=0.0, foreach=False
+    )
+
+
+def batch_loss(
+    model: AtomicNNUEV3,
+    batch: AtomicV3Batch,
+    *,
+    lambda_: float = 0.5,
+    validate: bool = True,
+) -> torch.Tensor:
+    if validate:
+        validate_batch(batch)
+    prediction = model(batch, validate=False)
+    loss = atomic_loss(prediction, batch.outcome, batch.score, lambda_=lambda_)
+    if not torch.isfinite(loss):
+        raise FloatingPointError("Atomic V3 loss is not finite")
+    return loss
+
+
+def optimizer_step(
+    model: AtomicNNUEV3,
+    optimizer: torch.optim.Optimizer,
+    batch: AtomicV3Batch,
+    *,
+    lambda_: float = 0.5,
+) -> float:
+    # Both the forward and the post-step state must be serializable by the
+    # frozen mixed-width wire.  In particular, clipping the HM factors
+    # independently is insufficient: ``clip_weights`` constrains their
+    # exported bucket+virtual sums.
+    model.clip_weights()
+    loss = batch_loss(model, batch, lambda_=lambda_)
+    optimizer.zero_grad(set_to_none=True)
+    loss.backward()
+    for parameter in model.parameters():
+        gradient = parameter.grad
+        if gradient is None:
+            continue
+        values = gradient.coalesce().values() if gradient.is_sparse else gradient
+        if not torch.all(torch.isfinite(values)):
+            raise FloatingPointError("Atomic V3 gradient is not finite")
+    optimizer.step()
+    model.clip_weights()
+    return float(loss.detach())
+
+
+def _active_rows(batch: AtomicV3Batch, attribute: str) -> list[int]:
+    rows: set[int] = set()
+    for perspective in (batch.white, batch.black):
+        indices = getattr(perspective, attribute).indices
+        rows.update(int(value) for value in indices.reshape(-1).tolist() if value != -1)
+    return sorted(rows)
+
+
+def _parameter_digest(model: AtomicNNUEV3, train: AtomicV3Batch) -> str:
+    transformer = model.feature_transformer
+    tensors = [
+        transformer.bias.detach(),
+        transformer.hm_bucket_weight.detach()[_active_rows(train, "hm")],
+        transformer.hm_virtual_weight.detach()[
+            sorted({row % 768 for row in _active_rows(train, "hm")})
+        ],
+        transformer.capture_pair_weight.detach()[_active_rows(train, "capture_pair")],
+        transformer.king_blast_ep_weight.detach()[_active_rows(train, "king_blast_ep")],
+        transformer.blast_ring_weight.detach()[_active_rows(train, "blast_ring")],
+        *(parameter.detach() for parameter in model.network.parameters()),
+    ]
+    digest = hashlib.sha256()
+    for tensor in tensors:
+        array = tensor.cpu().contiguous().numpy().astype(np.dtype("<f4"), copy=False)
+        digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def deterministic_cpu_one_step(
+    seed: int = 20260716, learning_rate: float = 1.0e-3
+) -> OneStepResult:
+    if isinstance(seed, bool) or not isinstance(seed, int):
+        raise TypeError("seed must be an integer")
+    if seed < 0 or seed > (1 << 64) - 1:
+        raise ValueError("seed must be in the non-negative uint64 domain")
+    if isinstance(learning_rate, bool) or not isinstance(learning_rate, (int, float)):
+        raise TypeError("learning_rate must be a real number")
+    learning_rate = float(learning_rate)
+    if not math.isfinite(learning_rate) or learning_rate <= 0:
+        raise ValueError("learning_rate must be finite and positive")
+    previous_threads = torch.get_num_threads()
+    deterministic_before = torch.are_deterministic_algorithms_enabled()
+    torch.set_num_threads(1)
+    torch.use_deterministic_algorithms(True)
+    try:
+        torch.manual_seed(seed)
+        fixture = load_canonical_fixture()
+        # Role order is preserved exactly as authenticated by the fixture.
+        train = fixture.batch("train")
+        validation = fixture.batch("validation")
+        model = AtomicNNUEV3(initialize=False).cpu()
+        model.clip_weights()
+        optimizer = create_core_optimizer(model, learning_rate)
+
+        train_before_tensor = batch_loss(model, train)
+        with torch.no_grad():
+            validation_before_tensor = batch_loss(model, validation)
+        train_before = float(train_before_tensor.detach())
+        validation_before = float(validation_before_tensor.detach())
+        optimizer.zero_grad(set_to_none=True)
+        train_before_tensor.backward()
+        for parameter in model.parameters():
+            gradient = parameter.grad
+            if gradient is None:
+                continue
+            values = gradient.coalesce().values() if gradient.is_sparse else gradient
+            if not torch.all(torch.isfinite(values)):
+                raise FloatingPointError("Atomic V3 fixture gradient is not finite")
+        optimizer.step()
+        model.clip_weights()
+
+        with torch.no_grad():
+            train_after = float(batch_loss(model, train).detach())
+            validation_after = float(batch_loss(model, validation).detach())
+        result = OneStepResult(
+            train_loss_before=train_before,
+            train_loss_after=train_after,
+            validation_loss_before=validation_before,
+            validation_loss_after=validation_after,
+            parameter_sha256=_parameter_digest(model, train),
+        )
+        if not all(
+            np.isfinite(value)
+            for value in (
+                result.train_loss_before,
+                result.train_loss_after,
+                result.validation_loss_before,
+                result.validation_loss_after,
+            )
+        ):
+            raise FloatingPointError("Atomic V3 CPU one-step produced a non-finite metric")
+        del optimizer, model, train_before_tensor, validation_before_tensor
+        gc.collect()
+        return result
+    finally:
+        torch.use_deterministic_algorithms(deterministic_before)
+        torch.set_num_threads(previous_threads)

--- a/atomic_v3/training.py
+++ b/atomic_v3/training.py
@@ -151,10 +151,19 @@ def deterministic_cpu_one_step(
         raise ValueError("learning_rate must be finite and positive")
     previous_threads = torch.get_num_threads()
     deterministic_before = torch.are_deterministic_algorithms_enabled()
+    deterministic_warn_only_before = (
+        torch.is_deterministic_algorithms_warn_only_enabled()
+    )
+    cpu_rng_before = torch.random.get_rng_state()
+    cuda_was_initialized = torch.cuda.is_initialized()
+    cuda_rng_before = torch.cuda.get_rng_state_all() if cuda_was_initialized else None
     torch.set_num_threads(1)
     torch.use_deterministic_algorithms(True)
     try:
-        torch.manual_seed(seed)
+        # Seed only the CPU generator used by this CPU-only healthcheck.
+        # torch.manual_seed() would also alter CUDA generators (or enqueue a
+        # lazy CUDA seed), violating isolation from the real training run.
+        torch.random.default_generator.manual_seed(seed)
         fixture = load_canonical_fixture()
         # Role order is preserved exactly as authenticated by the fixture.
         train = fixture.batch("train")
@@ -204,5 +213,14 @@ def deterministic_cpu_one_step(
         gc.collect()
         return result
     finally:
-        torch.use_deterministic_algorithms(deterministic_before)
-        torch.set_num_threads(previous_threads)
+        try:
+            torch.random.set_rng_state(cpu_rng_before)
+            if cuda_rng_before is not None:
+                torch.cuda.set_rng_state_all(cuda_rng_before)
+        finally:
+            # ``warn_only`` is independent global state. Preserve it as well,
+            # and restore the execution settings even if an RNG backend raises.
+            torch.use_deterministic_algorithms(
+                deterministic_before, warn_only=deterministic_warn_only_before
+            )
+            torch.set_num_threads(previous_threads)

--- a/docs/atomic-nnue-v3-trainer-core.md
+++ b/docs/atomic-nnue-v3-trainer-core.md
@@ -38,6 +38,13 @@ the explicit `provider_factory`. A prior `CampaignInspectionSnapshot` is for
 display and diagnostics only and cannot be passed as authority. There is no
 loader auto-detection or legacy fallback.
 
+Each authenticated read freezes one absolute lexical provenance label before
+opening the descriptor and returns that label together with the descriptor
+identity and immutable bytes. No `resolve()` occurs after authentication, so a
+post-read symlink swap cannot redirect the reported campaign parent or manifest
+discovery into another tree. Labels remain non-authoritative; consumers use the
+authenticated manifest bytes and hashes.
+
 The factory receives the fresh immutable manifest bytes as `manifest_payloads`,
 together with paths, expected hashes and record counts. A native adapter MUST
 parse those supplied bytes rather than reopen a manifest as unauthenticated
@@ -69,19 +76,30 @@ immediately after the update. Mixed i16/i8 tables, the inward float32-safe PSQT
 i32 envelope, all dense signed-i32 biases and both HM/FC0 factor sums are
 therefore exportable at every persistent step boundary. FC0 bias and weight
 limits apply to the serialized base+factor value, not just to each training
-factor independently. FC0 biases are coalesced and saturated in float64, written
-back as coordinated float32 operands, and then checked using both float32 and
-float64 addition before control returns. This prevents both the `+2147483648`
-float32 half-ulp overflow and the `-2147483776` value exposed only by float64
-coalescing. No signed-i32 cast is attempted before the range check, and
-non-finite dense biases fail closed.
+factor independently. FC0 biases and factorized HM PSQT weights are coalesced
+and saturated in float64, written back as coordinated float32 operands, and
+then checked using the real wire rounding from both float32 and float64 addition
+before control returns. This prevents both the FC0 `+2147483648` float32
+half-ulp overflow / `-2147483776` float64 overflow and the analogous HM PSQT
+opposite-sign cancellation at the 9,600 scale. No signed-i32 cast is attempted
+before the range check, and non-finite dense biases or factorized i32 sums fail
+closed.
+
+The opt-in `cuda-required` CI job exercises this same clamp on CUDA with both
+opposite-sign edge pairs, then runs an Atomic V3 forward/backward and controlled
+optimizer step. Setting `ATOMIC_REQUIRE_CUDA_TESTS=1` makes a missing CUDA/CuPy
+runtime a session error rather than a skip.
 
 ## Deliberate milestone limits
 
 H9.3l-j proves indexing, factorization, mixed feature forward, loss and a finite
 deterministic production-shape CPU step. The step uses state-free SGD only to
 exercise sparse table gradients without pre-empting the first-run optimizer
-discussion. It is not the production schedule.
+discussion. It is transparent to the caller's CPU RNG and to every already
+initialized CUDA RNG, including on exceptions, and it never initializes CUDA
+just to run the CPU healthcheck. The caller's thread count and deterministic
+algorithm mode, including PyTorch's independent `warn_only` flag, are restored
+as well. It is not the production schedule.
 
 Checkpoint/network serialization, final dependency/environment binding,
 controlled execution evidence and the first real training run belong to

--- a/docs/atomic-nnue-v3-trainer-core.md
+++ b/docs/atomic-nnue-v3-trainer-core.md
@@ -1,0 +1,89 @@
+# AtomicNNUEV3 trainer core (H9.3l-j)
+
+`atomic_v3/` is an isolated trainer backend for the wire-v1 architecture
+frozen by Atomic-Stockfish ADR 0004. It does not register a generic feature
+name, change the legacy command line or import `atomic_v2`.
+
+The feature transformer has six parameter tensors:
+
+- 1,024 signed-i16 accumulator biases;
+- factorized HalfKAv2AtomicHM training rows `[24576, 1032]` plus virtual rows
+  `[768, 1032]`;
+- CapturePair `[40012, 1024]` with signed-i8 export precision;
+- KingBlastEP `[2304, 1024]` with signed-i16 export precision;
+- BlastRing `[10240, 1024]` with signed-i8 export precision.
+
+Only HM owns the final eight columns. Its bucket row and virtual row are added
+before mixed fake quantization, including PSQT, matching the frozen 12-to-11
+export rule. Relation slices have no PSQT parameters. The dense tail is the
+eight-stack SFNNv15 graph shared with AtomicNNUEV2, including pairwise
+multiplication, squared paths and the FC0 `[30] - [31]` skip.
+
+## Dataset boundary
+
+A campaign filename and a Python object are not authentication roots.
+`inspect_campaign_roles` and `create_role_provider` require the path of the
+strict H9.3l-a publication receipt plus its exact expected SHA-256. That digest
+must arrive out of process from the authenticated controller or content-addressed
+store; accepting a digest supplied by arbitrary code already running in the
+trainer process does not add authenticity. Accordingly, arbitrary same-process
+Python code is explicitly inside this boundary and there is no issuer,
+unforgeable-handle or duck-typed capability claim.
+
+Every `create_role_provider` call starts again from the external receipt digest.
+It opens stable regular-file descriptors, rejects symlinks and Windows reparse
+points in the complete path, and re-reads and re-hashes the receipt, campaign and
+every ordered train/validation Atomic BIN V2 manifest immediately before calling
+the explicit `provider_factory`. A prior `CampaignInspectionSnapshot` is for
+display and diagnostics only and cannot be passed as authority. There is no
+loader auto-detection or legacy fallback.
+
+The factory receives the fresh immutable manifest bytes as `manifest_payloads`,
+together with paths, expected hashes and record counts. A native adapter MUST
+parse those supplied bytes rather than reopen a manifest as unauthenticated
+metadata; the accompanying metadata paths are provenance labels, not authority.
+It MUST also authenticate each shard named by the manifest immediately at its
+own I/O boundary; authenticated manifest bytes do not authenticate a later,
+mutable shard path. This milestone adds the strict receipt JSON contract, not a
+signing system: key management and signatures remain the controller/CAS layer's
+responsibility.
+
+The repository fixture is separately SHA-pinned and retains canonical sample
+order. Its train and validation roles are disjoint and are validated
+independently before any model allocation. The fixture is forced to LF by
+`.gitattributes`, so the authenticated bytes do not change on Windows.
+
+The isolated backend remains import-compatible with CPython 3.9 through 3.12.
+Its runtime modules avoid PEP 604 unions and dataclass options introduced after
+3.9; CI compiles and imports every `atomic_v3` module at each supported minor.
+
+Every batch must contain exactly `piece_count` active HM rows in both
+perspectives. Each perspective is decoded back to an absolute-color board and
+must contain one king per color, at most 16 pieces per color and at most one
+piece per square; the WHITE and BLACK reconstructions must agree exactly.
+Outcomes are restricted to `0`, `0.5` or `1`, while scores must be integral
+signed-i32 values represented in the float32 training tensor.
+
+The controlled optimizer helper clips immediately before the forward and
+immediately after the update. Mixed i16/i8 tables, the inward float32-safe PSQT
+i32 envelope, all dense signed-i32 biases and both HM/FC0 factor sums are
+therefore exportable at every persistent step boundary. FC0 bias and weight
+limits apply to the serialized base+factor value, not just to each training
+factor independently. FC0 biases are coalesced and saturated in float64, written
+back as coordinated float32 operands, and then checked using both float32 and
+float64 addition before control returns. This prevents both the `+2147483648`
+float32 half-ulp overflow and the `-2147483776` value exposed only by float64
+coalescing. No signed-i32 cast is attempted before the range check, and
+non-finite dense biases fail closed.
+
+## Deliberate milestone limits
+
+H9.3l-j proves indexing, factorization, mixed feature forward, loss and a finite
+deterministic production-shape CPU step. The step uses state-free SGD only to
+exercise sparse table gradients without pre-empting the first-run optimizer
+discussion. It is not the production schedule.
+
+Checkpoint/network serialization, final dependency/environment binding,
+controlled execution evidence and the first real training run belong to
+H9.3l-k and later milestones. Nothing in this backend claims training
+publication readiness.

--- a/requirements-CPU.txt
+++ b/requirements-CPU.txt
@@ -1,5 +1,6 @@
 chess==1.11.2
-matplotlib==3.10.8
+matplotlib==3.9.4; python_version < "3.10"
+matplotlib==3.10.8; python_version >= "3.10"
 numpy==1.26.4
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.7.1+cpu

--- a/tests/fixtures/atomic_v3/trainer-core-v1.json
+++ b/tests/fixtures/atomic_v3/trainer-core-v1.json
@@ -1,0 +1,75 @@
+{
+  "fixture_schema": "atomic-v3-trainer-core-v1",
+  "feature_schema_sha256": "9d3c77a58e5e55ac1bc798dab41977451eb523fce1d6fd3ec3f7c1e574a78750",
+  "campaign_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+  "collection_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+  "roles": {
+    "train": [
+      {
+        "sample_id": "train-000",
+        "side_to_move": "WHITE",
+        "piece_count": 8,
+        "outcome": 1.0,
+        "score": 210,
+        "white": {
+          "own_king_square": 4,
+          "hm": [24452, 24323, 24192, 23820, 24572, 24443, 24312, 23924],
+          "capture_pair": [0, 5, 39984],
+          "king_blast_ep": [0, 17, 2303],
+          "blast_ring": [0, 159, 10239]
+        },
+        "black": {
+          "own_king_square": 60,
+          "hm": [24572, 24443, 24312, 23924, 24452, 24323, 24192, 23820],
+          "capture_pair": [6, 20000, 39998],
+          "king_blast_ep": [18, 35, 2268],
+          "blast_ring": [5, 320, 10000]
+        }
+      },
+      {
+        "sample_id": "train-001",
+        "side_to_move": "BLACK",
+        "piece_count": 16,
+        "outcome": 0.0,
+        "score": -175,
+        "white": {
+          "own_king_square": 1,
+          "hm": [22918, 22788, 22663, 22656, 22421, 22533, 22287, 22283, 23038, 22908, 22783, 22776, 22509, 22653, 22391, 22387],
+          "capture_pair": [84, 420, 39997],
+          "king_blast_ep": [216, 450],
+          "blast_ring": [640, 1280, 9000]
+        },
+        "black": {
+          "own_king_square": 57,
+          "hm": [23038, 22908, 22783, 22776, 22509, 22653, 22391, 22387, 22918, 22788, 22663, 22656, 22421, 22533, 22287, 22283],
+          "capture_pair": [980, 1876, 40011],
+          "king_blast_ep": [72, 900],
+          "blast_ring": [80, 2560, 8000]
+        }
+      }
+    ],
+    "validation": [
+      {
+        "sample_id": "validation-000",
+        "side_to_move": "WHITE",
+        "piece_count": 4,
+        "outcome": 0.5,
+        "score": -1,
+        "white": {
+          "own_king_square": 7,
+          "hm": [22151, 22030, 22271, 22134],
+          "capture_pair": [1, 39985],
+          "king_blast_ep": [1, 16],
+          "blast_ring": [1, 79]
+        },
+        "black": {
+          "own_king_square": 63,
+          "hm": [22271, 22134, 22151, 22030],
+          "capture_pair": [7, 39999],
+          "king_blast_ep": [19, 34],
+          "blast_ring": [6, 74]
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_atomic_v3_backend_isolation.py
+++ b/tests/test_atomic_v3_backend_isolation.py
@@ -1,0 +1,22 @@
+import inspect
+
+import atomic_v2
+import feature_set
+import model as legacy_model
+
+import atomic_v3
+from atomic_v3.dataset import create_role_provider
+
+
+def test_v3_is_not_registered_in_legacy_or_v2_dispatch():
+    assert atomic_v3 is not atomic_v2
+    assert atomic_v3.BACKEND_KEY == "atomic-nnue-v3"
+    assert "atomic_v3" not in inspect.getsource(feature_set)
+    assert "atomic_v3" not in inspect.getsource(legacy_model)
+
+
+def test_v3_campaign_seam_has_no_implicit_native_or_legacy_loader_import():
+    source = inspect.getsource(create_role_provider)
+    assert "provider_factory" in source
+    assert "nnue_dataset" not in source
+    assert "atomic_v2" not in source

--- a/tests/test_atomic_v3_contract_indices.py
+++ b/tests/test_atomic_v3_contract_indices.py
@@ -1,0 +1,187 @@
+import pytest
+
+from atomic_v3 import BACKEND_KEY, BACKEND_NAME, FEATURE_NAME
+from atomic_v3.contract import (
+    ACCUMULATOR_DIMENSIONS,
+    BLAST_RING_DIMENSIONS,
+    CAPTURE_PAIR_DIMENSIONS,
+    FEATURE_HASH,
+    HM_OUTPUT_DIMENSIONS,
+    HM_PHYSICAL_DIMENSIONS,
+    HM_TRAINING_DIMENSIONS,
+    HM_VIRTUAL_DIMENSIONS,
+    KING_BLAST_EP_DIMENSIONS,
+    MAX_ACTIVE_FACTORIZED,
+    MAX_ACTIVE_PHYSICAL,
+    NETWORK_HASH,
+    PHYSICAL_DIMENSIONS,
+    SLICE_HASHES,
+    TRANSFORMER_DESCRIPTOR,
+    TRANSFORMER_DESCRIPTOR_HASH,
+    TRAINING_PARAMETER_ROWS,
+    fnv1a_32,
+    fold_slice_hashes,
+)
+from atomic_v3.indices import (
+    ActorRelation,
+    CollateralRelation,
+    Perspective,
+    blast_ring_index,
+    capture_pair_ep_index,
+    capture_pair_normal_index,
+    hm_export_sources,
+    hm_physical_index,
+    hm_training_index,
+    hm_virtual_index,
+    king_blast_ep_index,
+    make_joint_orientation,
+    network_bucket,
+    psqt_perspective_difference,
+    scale_raw_output,
+    trunc_div_toward_zero,
+)
+
+
+def test_v3_identity_and_all_frozen_dimensions_are_exact():
+    assert BACKEND_KEY == "atomic-nnue-v3"
+    assert BACKEND_NAME == "AtomicNNUEV3"
+    assert FEATURE_NAME == "HalfKAv2AtomicHM+CapturePair+KingBlastEP+BlastRing"
+    assert (HM_TRAINING_DIMENSIONS, HM_VIRTUAL_DIMENSIONS, HM_PHYSICAL_DIMENSIONS) == (
+        24_576,
+        768,
+        22_528,
+    )
+    assert HM_OUTPUT_DIMENSIONS == ACCUMULATOR_DIMENSIONS + 8 == 1_032
+    assert (CAPTURE_PAIR_DIMENSIONS, KING_BLAST_EP_DIMENSIONS, BLAST_RING_DIMENSIONS) == (
+        40_012,
+        2_304,
+        10_240,
+    )
+    assert PHYSICAL_DIMENSIONS == 75_084
+    assert TRAINING_PARAMETER_ROWS == 77_900
+    assert (MAX_ACTIVE_PHYSICAL, MAX_ACTIVE_FACTORIZED) == (547, 579)
+    assert SLICE_HASHES == (0xA34A8666, 0x9AEDB186, 0xF5172BC0, 0x38377946)
+    assert fold_slice_hashes() == FEATURE_HASH == 0xA3FBDBE8
+    assert NETWORK_HASH == 0x0CF9A484
+
+
+def test_global_transformer_descriptor_is_the_exact_engine_wire_identity():
+    encoded = TRANSFORMER_DESCRIPTOR.encode("ascii")
+    assert len(encoded) == 799
+    assert fnv1a_32(encoded) == TRANSFORMER_DESCRIPTOR_HASH == 0xCC31067A
+    assert encoded.startswith(b"AtomicNNUEV3Transformer|v1|")
+    assert encoded.endswith(b"|strict_eof=true")
+
+
+@pytest.mark.parametrize(
+    "perspective,king,vertical,horizontal,oriented,bucket",
+    [
+        (Perspective.WHITE, 0, 0, 7, 7, 28),
+        (Perspective.WHITE, 4, 0, 0, 4, 31),
+        (Perspective.WHITE, 63, 0, 0, 63, 0),
+        (Perspective.BLACK, 56, 56, 7, 7, 28),
+        (Perspective.BLACK, 60, 56, 0, 4, 31),
+        (Perspective.BLACK, 7, 56, 0, 63, 0),
+    ],
+)
+def test_joint_orientation_is_perspective_local_and_bucket_exact(
+    perspective, king, vertical, horizontal, oriented, bucket
+):
+    value = make_joint_orientation(perspective, king)
+    assert (value.vertical_xor, value.horizontal_xor) == (vertical, horizontal)
+    assert value.oriented_own_king == oriented
+    assert value.king_bucket == bucket
+    assert value.orient(king) == oriented
+
+
+def test_hm_factorization_and_12_to_11_king_merge_boundaries():
+    assert hm_training_index(0, 0, 0) == 0
+    assert hm_training_index(31, 11, 63) == 24_575
+    assert hm_virtual_index(0, 0) == 0
+    assert hm_virtual_index(11, 63) == 767
+    assert hm_physical_index(31, 10, 63) == 22_527
+
+    # Merged king takes OWN_KING at the oriented own king and OPP_KING elsewhere.
+    assert hm_export_sources(31, 10, 4, 4) == (
+        hm_training_index(31, 10, 4),
+        hm_virtual_index(10, 4),
+    )
+    assert hm_export_sources(31, 10, 60, 4) == (
+        hm_training_index(31, 11, 60),
+        hm_virtual_index(11, 60),
+    )
+
+
+def test_relation_index_formulas_hit_every_frozen_endpoint():
+    assert capture_pair_normal_index(ActorRelation.OWN, 0, 0) == 0
+    assert capture_pair_normal_index(ActorRelation.OPP, 3331, 5) == 39_983
+    assert capture_pair_ep_index(ActorRelation.OWN, 0) == 39_984
+    assert capture_pair_ep_index(ActorRelation.OPP, 13) == 40_011
+    assert king_blast_ep_index(0, ActorRelation.OWN, 0) == 0
+    assert king_blast_ep_index(63, ActorRelation.OPP, 17) == 2_303
+    assert blast_ring_index(
+        0, ActorRelation.OWN, CollateralRelation.OWN, 0, 0
+    ) == 0
+    assert blast_ring_index(
+        63, ActorRelation.OPP, CollateralRelation.OPP, 7, 4
+    ) == 10_239
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: hm_training_index(32, 0, 0),
+        lambda: hm_virtual_index(12, 0),
+        lambda: capture_pair_normal_index(0, 3332, 0),
+        lambda: capture_pair_ep_index(1, 14),
+        lambda: king_blast_ep_index(64, 0, 0),
+        lambda: blast_ring_index(0, 0, 0, 8, 0),
+        lambda: network_bucket(1),
+    ],
+)
+def test_index_oracles_fail_closed_outside_the_domain(call):
+    with pytest.raises((TypeError, ValueError)):
+        call()
+
+
+def test_signed_arithmetic_matches_cpp_truncation_not_python_flooring():
+    assert [trunc_div_toward_zero(value, 2) for value in (-5, -3, -1, 1, 3, 5)] == [
+        -2,
+        -1,
+        0,
+        0,
+        1,
+        2,
+    ]
+    assert psqt_perspective_difference(-2, 1) == -1
+    assert psqt_perspective_difference(2, -1) == 1
+    assert scale_raw_output(-1) == 0
+    assert scale_raw_output(-3_665_038_760) == -(1 << 31)
+    assert scale_raw_output(3_665_038_759) == (1 << 31) - 1
+
+
+def test_signed_arithmetic_rejects_bool_and_overflow_inputs():
+    with pytest.raises(TypeError):
+        trunc_div_toward_zero(True, 2)
+    with pytest.raises(ValueError):
+        scale_raw_output(3_665_038_760)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: make_joint_orientation(True, 4),
+        lambda: capture_pair_normal_index(False, 0, 0),
+        lambda: capture_pair_ep_index(True, 0),
+        lambda: king_blast_ep_index(0, False, 0),
+        lambda: blast_ring_index(0, 0, True, 0, 0),
+    ],
+)
+def test_integer_enums_reject_bool_aliases(call):
+    with pytest.raises(TypeError, match="integer enum"):
+        call()
+
+
+@pytest.mark.parametrize("count,expected", [(2, 0), (4, 0), (5, 1), (32, 7)])
+def test_shared_network_bucket_formula(count, expected):
+    assert network_bucket(count) == expected

--- a/tests/test_atomic_v3_dataset.py
+++ b/tests/test_atomic_v3_dataset.py
@@ -307,6 +307,48 @@ def test_provider_factory_consumes_the_fresh_manifest_bytes_not_mutable_path_aut
     )
 
 
+def test_post_authentication_symlink_swap_cannot_retarget_provenance_parent(
+    tmp_path, monkeypatch
+):
+    original = tmp_path / "original"
+    alternate = tmp_path / "alternate"
+    original.mkdir()
+    alternate.mkdir()
+    campaign, receipt, receipt_sha256, train, validation, _ = _campaign(original)
+    for artifact in (campaign, train, validation):
+        (alternate / artifact.name).write_bytes(artifact.read_bytes())
+
+    authenticated_read = v3_dataset._read_regular_authenticated
+    swapped = False
+
+    def race_after_authenticated_read(path, *args, **kwargs):
+        nonlocal swapped
+        snapshot = authenticated_read(path, *args, **kwargs)
+        if Path(path) == campaign and not swapped:
+            swapped = True
+            campaign.unlink()
+            try:
+                campaign.symlink_to(alternate / campaign.name)
+            except OSError as error:
+                pytest.skip(f"platform cannot create the symlink race fixture: {error}")
+        return snapshot
+
+    monkeypatch.setattr(
+        v3_dataset, "_read_regular_authenticated", race_after_authenticated_read
+    )
+    snapshot = inspect_campaign_roles(campaign, receipt, receipt_sha256)
+
+    # The immutable bytes and lexical path captured by the authenticated read
+    # stay paired. A later resolve() must not redirect manifest discovery or
+    # provenance labels into the alternate tree.
+    assert swapped
+    assert snapshot.campaign_path == Path(os.path.abspath(str(campaign)))
+    assert snapshot.campaign_path.parent == original
+    assert snapshot.train[0].path == train
+    assert snapshot.validation[0].path == validation
+    assert all(item.path.parent != alternate for item in snapshot.train + snapshot.validation)
+
+
 def test_publication_receipt_is_strict_sized_duplicate_free_json(tmp_path):
     campaign, receipt, _, _, _, receipt_document = _campaign(tmp_path)
     duplicate = json.dumps(receipt_document)[:-1] + ',"receipt_format":"duplicate"}\n'

--- a/tests/test_atomic_v3_dataset.py
+++ b/tests/test_atomic_v3_dataset.py
@@ -1,0 +1,517 @@
+import dataclasses
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import atomic_v3.dataset as v3_dataset
+from atomic_v3.contract import (
+    CAMPAIGN_SCHEMA_SHA256,
+    FEATURE_SCHEMA_SHA256,
+    PUBLICATION_CONTRACT_COMMIT,
+    PUBLICATION_SCHEMA_SHA256,
+    PUBLICATION_VALIDATOR_CONTRACT,
+)
+from atomic_v3.dataset import (
+    ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256,
+    CANONICAL_FIXTURE_SHA256,
+    MAX_RECEIPT_BYTES,
+    PUBLICATION_RECEIPT_FORMAT,
+    AtomicV3Batch,
+    DatasetContractError,
+    PerspectiveBatch,
+    SparseSliceBatch,
+    create_role_provider,
+    inspect_campaign_roles,
+    load_canonical_fixture,
+    validate_batch,
+)
+from atomic_v3.indices import Perspective, hm_training_index, make_joint_orientation
+
+
+def _artifact(path):
+    payload = path.read_bytes()
+    return {
+        "file": path.name,
+        "bytes": str(len(payload)),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "schema_sha256": ATOMIC_BIN_V2_MANIFEST_SCHEMA_SHA256,
+    }
+
+
+def _write_json(path, document):
+    path.write_bytes(
+        (json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    )
+
+
+def _sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_receipt(path, document):
+    _write_json(path, document)
+    return _sha256(path)
+
+
+def _campaign(tmp_path):
+    train = tmp_path / "chunk-0-train.atbin.manifest.json"
+    validation = tmp_path / "chunk-0-validation.atbin.manifest.json"
+    train.write_bytes(b'{"role":"train"}\n')
+    validation.write_bytes(b'{"role":"validation"}\n')
+    collection = "2" * 64
+    document = {
+        "schema_version": 1,
+        "campaign_id": "trainer-campaign-fixture",
+        "status": "completed",
+        "schemas": {"feature": FEATURE_SCHEMA_SHA256},
+        "chunks": [
+            {
+                "index": "0",
+                "train": {
+                    "first_record": "0",
+                    "records": "2",
+                    "manifest": _artifact(train),
+                },
+                "validation": {
+                    "first_record": "0",
+                    "records": "1",
+                    "manifest": _artifact(validation),
+                },
+            }
+        ],
+        "totals": {"train_records": "2", "validation_records": "1", "records": "3"},
+        "collection_sha256": collection,
+    }
+    campaign = tmp_path / "campaign.json"
+    _write_json(campaign, document)
+    receipt_document = {
+        "receipt_format": PUBLICATION_RECEIPT_FORMAT,
+        "validator_contract": PUBLICATION_VALIDATOR_CONTRACT,
+        "publication_contract_commit": PUBLICATION_CONTRACT_COMMIT,
+        "publication_schema_sha256": dict(PUBLICATION_SCHEMA_SHA256),
+        "campaign_schema_sha256": CAMPAIGN_SCHEMA_SHA256,
+        "campaign_sha256": _sha256(campaign),
+        "collection_sha256": collection,
+        "feature_schema_sha256": FEATURE_SCHEMA_SHA256,
+        "producer_attestation_sha256": "3" * 64,
+        "semantic_audit_sha256": "4" * 64,
+        "reachability_attestation_sha256": "5" * 64,
+        "dataset_publication_ready": True,
+    }
+    receipt = tmp_path / "publication-receipt.json"
+    receipt_sha256 = _write_receipt(receipt, receipt_document)
+    return campaign, receipt, receipt_sha256, train, validation, receipt_document
+
+
+def test_canonical_fixture_preserves_role_and_sample_order_separately():
+    fixture = load_canonical_fixture()
+    assert [sample["sample_id"] for sample in fixture.roles["train"]] == [
+        "train-000",
+        "train-001",
+    ]
+    assert [sample["sample_id"] for sample in fixture.roles["validation"]] == [
+        "validation-000"
+    ]
+    assert fixture.batch("train").batch_size == 2
+    assert fixture.batch("validation").batch_size == 1
+
+
+def test_canonical_fixture_bytes_and_checkout_policy_are_lf_stable():
+    fixture_path = Path(__file__).parent / "fixtures" / "atomic_v3" / "trainer-core-v1.json"
+    raw = fixture_path.read_bytes()
+    assert b"\r" not in raw
+    assert raw.endswith(b"\n")
+    assert hashlib.sha256(raw).hexdigest() == CANONICAL_FIXTURE_SHA256
+    attributes = (Path(__file__).parents[1] / ".gitattributes").read_text(encoding="utf-8")
+    assert "tests/fixtures/atomic_v3/*.json text eol=lf" in attributes.splitlines()
+
+
+def test_campaign_requires_receipt_before_opening_any_role_manifest(tmp_path):
+    campaign, receipt, _, train, _, receipt_document = _campaign(tmp_path)
+    train.unlink()
+    rejected = dict(receipt_document)
+    rejected["dataset_publication_ready"] = False
+    expected_receipt_sha256 = _write_receipt(receipt, rejected)
+    with pytest.raises(DatasetContractError, match="not dataset-publication-ready"):
+        inspect_campaign_roles(campaign, receipt, expected_receipt_sha256)
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("validator_contract", "unknown", "validator contract"),
+        ("publication_contract_commit", "0" * 40, "receipt commit"),
+        ("campaign_schema_sha256", "0" * 64, "campaign schema"),
+        ("feature_schema_sha256", "0" * 64, "feature schema"),
+        ("campaign_sha256", "0" * 64, "SHA-256 mismatch"),
+        ("collection_sha256", "0" * 64, "collection hash"),
+    ],
+)
+def test_campaign_receipt_mismatches_fail_closed(tmp_path, field, value, match):
+    campaign, receipt, _, _, _, receipt_document = _campaign(tmp_path)
+    rejected = dict(receipt_document)
+    rejected[field] = value
+    expected_receipt_sha256 = _write_receipt(receipt, rejected)
+    with pytest.raises(DatasetContractError, match=match):
+        inspect_campaign_roles(campaign, receipt, expected_receipt_sha256)
+
+
+def test_publication_receipt_requires_the_complete_merged_schema_set(tmp_path):
+    campaign, receipt, _, _, _, receipt_document = _campaign(tmp_path)
+    rejected = dict(receipt_document)
+    schemas = dict(receipt_document["publication_schema_sha256"])
+    schemas.pop("atomic-v3-semantic-audit-v1.json")
+    rejected["publication_schema_sha256"] = schemas
+    expected_receipt_sha256 = _write_receipt(receipt, rejected)
+    with pytest.raises(DatasetContractError, match="schema set differs"):
+        inspect_campaign_roles(campaign, receipt, expected_receipt_sha256)
+
+
+def test_authenticated_roles_are_ordered_and_pass_only_through_explicit_v3_factory(tmp_path):
+    campaign_path, receipt, receipt_sha256, train, validation, _ = _campaign(tmp_path)
+    snapshot = inspect_campaign_roles(campaign_path, receipt, receipt_sha256)
+    assert [item.path for item in snapshot.train] == [train]
+    assert [item.path for item in snapshot.validation] == [validation]
+
+    calls = []
+
+    def factory(**kwargs):
+        calls.append(kwargs)
+        return "provider"
+
+    assert (
+        create_role_provider(
+            campaign_path,
+            receipt,
+            receipt_sha256,
+            "train",
+            provider_factory=factory,
+            batch_size=128,
+        )
+        == "provider"
+    )
+    assert calls[0]["backend"] == "atomic-nnue-v3"
+    assert calls[0]["role"] == "train"
+    assert calls[0]["manifests"] == (str(train),)
+    assert calls[0]["manifest_sha256"] == (snapshot.train[0].sha256,)
+    assert calls[0]["manifest_records"] == (2,)
+    assert calls[0]["manifest_payloads"] == (train.read_bytes(),)
+    assert calls[0]["receipt_sha256"] == receipt_sha256
+    assert calls[0]["producer_attestation_sha256"] == "3" * 64
+    assert calls[0]["semantic_audit_sha256"] == "4" * 64
+    assert calls[0]["reachability_attestation_sha256"] == "5" * 64
+    assert calls[0]["batch_size"] == 128
+
+    forged_snapshot = dataclasses.replace(snapshot, campaign_id="forged")
+    with pytest.raises(TypeError, match="filesystem path"):
+        create_role_provider(
+            forged_snapshot,
+            receipt,
+            receipt_sha256,
+            "train",
+            provider_factory=factory,
+        )
+
+
+def test_no_same_process_capability_or_issuer_is_an_authentication_root():
+    exported_names = set(vars(v3_dataset))
+    assert not any("capability" in name or "issuer" in name for name in exported_names)
+    documentation = " ".join(v3_dataset.__doc__.split())
+    assert "arbitrary code in this process is inside the trust boundary" in documentation
+
+
+def test_role_manifest_is_reauthenticated_after_campaign_validation(tmp_path):
+    campaign, receipt, receipt_sha256, train, _, _ = _campaign(tmp_path)
+    train.write_bytes(b"changed after publication validation\n")
+    with pytest.raises(DatasetContractError, match="byte count mismatch|SHA-256 mismatch"):
+        inspect_campaign_roles(campaign, receipt, receipt_sha256)
+
+
+def test_malformed_or_duplicate_campaign_json_is_rejected_after_exact_hash_authentication(tmp_path):
+    campaign, receipt, _, _, _, receipt_document = _campaign(tmp_path)
+    campaign.write_text('{"schema_version":1,"schema_version":1}\n', encoding="utf-8")
+    receipt_document = dict(receipt_document)
+    receipt_document["campaign_sha256"] = _sha256(campaign)
+    receipt_sha256 = _write_receipt(receipt, receipt_document)
+    with pytest.raises(DatasetContractError, match="duplicate JSON property"):
+        inspect_campaign_roles(campaign, receipt, receipt_sha256)
+
+
+def test_train_and_validation_cannot_reuse_one_manifest_digest(tmp_path):
+    campaign, receipt, _, train, validation, receipt_document = _campaign(tmp_path)
+    validation.write_bytes(train.read_bytes())
+    document = json.loads(campaign.read_text(encoding="utf-8"))
+    document["chunks"][0]["validation"]["manifest"] = _artifact(validation)
+    _write_json(campaign, document)
+    receipt_document = dict(receipt_document)
+    receipt_document["campaign_sha256"] = _sha256(campaign)
+    receipt_sha256 = _write_receipt(receipt, receipt_document)
+    with pytest.raises(DatasetContractError, match="reuses a role manifest"):
+        inspect_campaign_roles(campaign, receipt, receipt_sha256)
+
+
+@pytest.mark.parametrize("artifact", ["receipt", "campaign", "manifest"])
+def test_provider_reauthenticates_every_file_after_an_inspection_snapshot(tmp_path, artifact):
+    campaign, receipt, receipt_sha256, train, _, _ = _campaign(tmp_path)
+    inspect_campaign_roles(campaign, receipt, receipt_sha256)
+    if artifact == "receipt":
+        receipt.write_bytes(b"{}\n")
+        match = "SHA-256 mismatch"
+    elif artifact == "campaign":
+        replacement = tmp_path / "replacement-campaign.json"
+        replacement.write_bytes(campaign.read_bytes() + b"\n")
+        os.replace(replacement, campaign)
+        match = "SHA-256 mismatch"
+    else:
+        train.write_bytes(train.read_bytes() + b"\n")
+        match = "byte count mismatch|SHA-256 mismatch"
+    calls = []
+    with pytest.raises(DatasetContractError, match=match):
+        create_role_provider(
+            campaign,
+            receipt,
+            receipt_sha256,
+            "train",
+            provider_factory=lambda **kwargs: calls.append(kwargs),
+        )
+    assert calls == []
+
+
+def test_provider_factory_consumes_the_fresh_manifest_bytes_not_mutable_path_authority(tmp_path):
+    campaign, receipt, receipt_sha256, train, _, _ = _campaign(tmp_path)
+    authenticated_payload = train.read_bytes()
+
+    def factory(**kwargs):
+        train.write_bytes(b"changed after factory entry\n")
+        assert kwargs["manifest_payloads"] == (authenticated_payload,)
+        assert hashlib.sha256(kwargs["manifest_payloads"][0]).hexdigest() == kwargs[
+            "manifest_sha256"
+        ][0]
+        return "provider"
+
+    assert (
+        create_role_provider(
+            campaign,
+            receipt,
+            receipt_sha256,
+            "train",
+            provider_factory=factory,
+        )
+        == "provider"
+    )
+
+
+def test_publication_receipt_is_strict_sized_duplicate_free_json(tmp_path):
+    campaign, receipt, _, _, _, receipt_document = _campaign(tmp_path)
+    duplicate = json.dumps(receipt_document)[:-1] + ',"receipt_format":"duplicate"}\n'
+    receipt.write_text(duplicate, encoding="utf-8")
+    with pytest.raises(DatasetContractError, match="duplicate JSON property"):
+        inspect_campaign_roles(campaign, receipt, _sha256(receipt))
+
+    receipt.write_bytes(b'{"receipt_format":NaN}\n')
+    with pytest.raises(DatasetContractError, match="nonstandard JSON constant"):
+        inspect_campaign_roles(campaign, receipt, _sha256(receipt))
+
+    rejected = dict(receipt_document)
+    rejected["extra"] = "not allowed"
+    with pytest.raises(DatasetContractError, match="fields differ"):
+        inspect_campaign_roles(campaign, receipt, _write_receipt(receipt, rejected))
+
+    rejected = dict(receipt_document)
+    rejected["dataset_publication_ready"] = 1
+    with pytest.raises(DatasetContractError, match="not dataset-publication-ready"):
+        inspect_campaign_roles(campaign, receipt, _write_receipt(receipt, rejected))
+
+    receipt.write_bytes(b" " * (MAX_RECEIPT_BYTES + 1))
+    with pytest.raises(DatasetContractError, match="byte limit"):
+        inspect_campaign_roles(campaign, receipt, _sha256(receipt))
+
+
+def test_symlink_and_reparse_receipts_are_rejected(tmp_path):
+    campaign, receipt, receipt_sha256, _, _, _ = _campaign(tmp_path)
+    link = tmp_path / "receipt-link.json"
+    try:
+        link.symlink_to(receipt)
+    except OSError:
+        link = None
+    if link is not None:
+        with pytest.raises(DatasetContractError, match="symbolic links and reparse points"):
+            inspect_campaign_roles(campaign, link, receipt_sha256)
+
+    linked_parent = tmp_path / "linked-parent"
+    try:
+        linked_parent.symlink_to(tmp_path, target_is_directory=True)
+    except OSError:
+        linked_parent = None
+    if linked_parent is not None:
+        with pytest.raises(DatasetContractError, match="symbolic links and reparse points"):
+            inspect_campaign_roles(
+                linked_parent / campaign.name,
+                linked_parent / receipt.name,
+                receipt_sha256,
+            )
+
+    synthetic_reparse = SimpleNamespace(
+        st_mode=stat.S_IFREG, st_file_attributes=v3_dataset._REPARSE_POINT
+    )
+    assert v3_dataset._is_link_or_reparse(synthetic_reparse)
+
+
+def test_orientation_bucket_and_slice_indices_fail_closed_in_batches():
+    fixture = load_canonical_fixture()
+    batch = fixture.batch("train")
+
+    wrong_hm = batch.white.hm.indices.clone()
+    wrong_hm[0, 0] = 0
+    wrong_white = dataclasses.replace(
+        batch.white, hm=dataclasses.replace(batch.white.hm, indices=wrong_hm)
+    )
+    with pytest.raises(DatasetContractError, match="HM feature uses a bucket"):
+        validate_batch(dataclasses.replace(batch, white=wrong_white))
+
+    wrong_relation = batch.black.capture_pair.indices.clone()
+    wrong_relation[0, 0] = 40_012
+    wrong_black = dataclasses.replace(
+        batch.black,
+        capture_pair=dataclasses.replace(batch.black.capture_pair, indices=wrong_relation),
+    )
+    with pytest.raises(DatasetContractError, match="escapes"):
+        validate_batch(dataclasses.replace(batch, black=wrong_black))
+
+    wrong_bucket = batch.bucket_indices.clone()
+    wrong_bucket[0] = 7
+    with pytest.raises(DatasetContractError, match="bucket does not match"):
+        validate_batch(dataclasses.replace(batch, bucket_indices=wrong_bucket))
+
+
+def test_relation_rows_must_be_sorted_unique_boolean_sets():
+    fixture = load_canonical_fixture()
+    batch = fixture.batch("train")
+    indices = batch.white.capture_pair.indices.clone()
+    indices[0, :2] = torch.tensor([5, 0], dtype=torch.int32)
+    changed = dataclasses.replace(
+        batch.white,
+        capture_pair=dataclasses.replace(batch.white.capture_pair, indices=indices),
+    )
+    with pytest.raises(DatasetContractError, match="canonical ascending"):
+        validate_batch(dataclasses.replace(batch, white=changed))
+
+
+def _hm_rows(perspective, own_king, board):
+    orientation = make_joint_orientation(perspective, own_king)
+    rows = []
+    for square, absolute_color, piece_kind in board:
+        own = absolute_color == int(perspective)
+        plane = (10 if own else 11) if piece_kind == 5 else piece_kind * 2 + (0 if own else 1)
+        rows.append(hm_training_index(orientation.king_bucket, plane, orientation.orient(square)))
+    return rows
+
+
+def _empty_relation(batch_size=1):
+    return SparseSliceBatch(
+        torch.full((batch_size, 1), -1, dtype=torch.int32),
+        torch.zeros((batch_size, 1), dtype=torch.float32),
+    )
+
+
+def _coherent_batch(board, white_king, black_king):
+    count = len(board)
+    relation = _empty_relation()
+
+    def perspective(which, king):
+        indices = torch.tensor([_hm_rows(which, king, board)], dtype=torch.int32)
+        return PerspectiveBatch(
+            own_king_squares=torch.tensor([king], dtype=torch.long),
+            hm=SparseSliceBatch(indices, torch.ones_like(indices, dtype=torch.float32)),
+            capture_pair=relation,
+            king_blast_ep=relation,
+            blast_ring=relation,
+        )
+
+    return AtomicV3Batch(
+        side_to_move_white=torch.ones((1, 1), dtype=torch.float32),
+        piece_counts=torch.tensor([count], dtype=torch.long),
+        white=perspective(Perspective.WHITE, white_king),
+        black=perspective(Perspective.BLACK, black_king),
+        outcome=torch.tensor([[0.5]], dtype=torch.float32),
+        score=torch.tensor([[0.0]], dtype=torch.float32),
+        bucket_indices=torch.tensor([(count - 1) // 4], dtype=torch.long),
+    )
+
+
+def test_hm_active_count_must_equal_piece_count_in_each_perspective():
+    batch = load_canonical_fixture().batch("train")
+    indices = batch.white.hm.indices.clone()
+    values = batch.white.hm.values.clone()
+    indices[0, 7] = -1
+    values[0, 7] = 0.0
+    white = dataclasses.replace(batch.white, hm=SparseSliceBatch(indices, values))
+    with pytest.raises(DatasetContractError, match="active HM count does not match"):
+        validate_batch(dataclasses.replace(batch, white=white))
+
+
+def test_hm_requires_one_king_per_relation_and_own_king_square_identity():
+    batch = load_canonical_fixture().batch("train")
+    indices = batch.white.hm.indices.clone()
+    # Reinterpret WHITE's own king on e1 as an own queen on e1.
+    indices[0, 0] -= 2 * 64
+    white = dataclasses.replace(
+        batch.white, hm=dataclasses.replace(batch.white.hm, indices=indices)
+    )
+    with pytest.raises(DatasetContractError, match="exactly one own and one opponent king"):
+        validate_batch(dataclasses.replace(batch, white=white))
+
+
+def test_hm_rejects_two_piece_planes_on_one_square():
+    batch = load_canonical_fixture().batch("train")
+    indices = batch.white.hm.indices.clone()
+    # Move the own queen plane onto the own king's oriented square.
+    indices[0, 1] += 1
+    white = dataclasses.replace(
+        batch.white, hm=dataclasses.replace(batch.white.hm, indices=indices)
+    )
+    with pytest.raises(DatasetContractError, match="more than one piece on square"):
+        validate_batch(dataclasses.replace(batch, white=white))
+
+
+def test_white_and_black_hm_must_reconstruct_the_identical_absolute_board():
+    batch = load_canonical_fixture().batch("train")
+    indices = batch.black.hm.indices.clone()
+    # Move BLACK's view of its own e7 pawn to f7 without changing cardinality.
+    indices[0, 7] += 1
+    black = dataclasses.replace(
+        batch.black, hm=dataclasses.replace(batch.black.hm, indices=indices)
+    )
+    with pytest.raises(DatasetContractError, match="do not reconstruct the same board"):
+        validate_batch(dataclasses.replace(batch, black=black))
+
+
+def test_hm_rejects_more_than_sixteen_pieces_for_one_color():
+    board = [(0, 0, 5)]
+    board.extend((square, 0, 0) for square in range(1, 17))
+    board.append((63, 1, 5))
+    board.extend((square, 1, 0) for square in range(49, 63))
+    batch = _coherent_batch(board, white_king=0, black_king=63)
+    with pytest.raises(DatasetContractError, match="more than 16 pieces"):
+        validate_batch(batch)
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("outcome", 0.25, "exactly one of"),
+        ("score", 1.5, "integer values"),
+        ("score", float(1 << 31), "int32 domain"),
+    ],
+)
+def test_label_domains_are_the_exact_wire_contract(field, value, match):
+    batch = load_canonical_fixture().batch("validation")
+    changed = torch.tensor([[value]], dtype=torch.float32)
+    with pytest.raises(DatasetContractError, match=match):
+        validate_batch(dataclasses.replace(batch, **{field: changed}))

--- a/tests/test_atomic_v3_model_training.py
+++ b/tests/test_atomic_v3_model_training.py
@@ -1,0 +1,478 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import atomic_v3.training as v3_training
+from atomic_v3.dataset import SparseSliceBatch, load_canonical_fixture
+from atomic_v3.dense import AtomicV3LayerStacks, fake_quantize_integer_bias
+from atomic_v3.model import AtomicNNUEV3, AtomicV3FeatureTransformer
+from atomic_v3.quantization import (
+    FC0_BIAS_EXPORT_MAX,
+    FC0_BIAS_EXPORT_MIN,
+    FC0_BIAS_SCALE,
+    FC0_WEIGHT_SCALE,
+    FC1_BIAS_EXPORT_MAX,
+    FC1_BIAS_EXPORT_MIN,
+    FC1_BIAS_SCALE,
+    FC2_BIAS_EXPORT_MAX,
+    FC2_BIAS_EXPORT_MIN,
+    FC2_BIAS_SCALE,
+    FT_ONE,
+    PSQT_EXPORT_MAX,
+    PSQT_EXPORT_MIN,
+    PSQT_WEIGHT_SCALE,
+    fake_quantize_i16_feature,
+    fake_quantize_i8_feature,
+    fake_quantize_psqt_output,
+    fake_quantize_psqt_weight,
+)
+from atomic_v3.training import (
+    atomic_loss,
+    create_core_optimizer,
+    deterministic_cpu_one_step,
+    optimizer_step,
+)
+
+
+def _slice(index=0):
+    return SparseSliceBatch(
+        torch.tensor([[index]], dtype=torch.int32),
+        torch.tensor([[1.0]], dtype=torch.float32),
+    )
+
+
+def _tiny_transformer():
+    transformer = AtomicV3FeatureTransformer.__new__(AtomicV3FeatureTransformer)
+    torch.nn.Module.__init__(transformer)
+    transformer.bias = torch.nn.Parameter(torch.zeros(1024))
+    transformer.hm_bucket_weight = torch.nn.Parameter(torch.zeros((1, 1032)))
+    transformer.hm_virtual_weight = torch.nn.Parameter(torch.zeros((1, 1032)))
+    transformer.capture_pair_weight = torch.nn.Parameter(torch.zeros((1, 1024)))
+    transformer.king_blast_ep_weight = torch.nn.Parameter(torch.zeros((1, 1024)))
+    transformer.blast_ring_weight = torch.nn.Parameter(torch.zeros((1, 1024)))
+    return transformer
+
+
+def _tiny_model():
+    model = AtomicNNUEV3.__new__(AtomicNNUEV3)
+    torch.nn.Module.__init__(model)
+    model.feature_transformer = _tiny_transformer()
+    model.network = AtomicV3LayerStacks()
+    return model
+
+
+def _fc0_serialized_integers(model, dtype):
+    base = model.network.fc0.linear.bias.to(dtype)
+    factor = model.network.fc0.factorized_linear.bias.repeat(8).to(dtype)
+    rounded = torch.round((base + factor) * FC0_BIAS_SCALE).to(torch.float64)
+    if torch.any(rounded < -(1 << 31)) or torch.any(rounded > (1 << 31) - 1):
+        raise OverflowError("FC0 bias is outside signed-i32 wire range")
+    return rounded.to(torch.int64)
+
+
+def _assert_fc0_serializable_in_both_widths(model):
+    for dtype in (torch.float32, torch.float64):
+        integers = _fc0_serialized_integers(model, dtype)
+        assert torch.all(integers >= -(1 << 31))
+        assert torch.all(integers <= (1 << 31) - 1)
+
+
+def test_v3_composed_transformer_factorizes_hm_and_gives_relations_no_psqt():
+    transformer = _tiny_transformer()
+    with torch.no_grad():
+        transformer.bias.fill_(0.25)
+        transformer.hm_bucket_weight[:, :1024].fill_(0.50)
+        transformer.hm_bucket_weight[:, 1024:].fill_(0.10)
+        transformer.hm_virtual_weight[:, :1024].fill_(0.25)
+        transformer.hm_virtual_weight[:, 1024:].fill_(0.20)
+        transformer.capture_pair_weight.fill_(0.10)
+        transformer.king_blast_ep_weight.fill_(-0.20)
+        transformer.blast_ring_weight.fill_(0.30)
+    perspective = SimpleNamespace(
+        hm=_slice(), capture_pair=_slice(), king_blast_ep=_slice(), blast_ring=_slice()
+    )
+
+    main, psqt = transformer.forward(perspective, fake_quantize_weights=False)
+
+    torch.testing.assert_close(main, torch.full((1, 1024), 1.20))
+    torch.testing.assert_close(psqt, torch.full((1, 8), 0.30))
+    assert transformer.capture_pair_weight.shape[1] == 1024
+    assert transformer.king_blast_ep_weight.shape[1] == 1024
+    assert transformer.blast_ring_weight.shape[1] == 1024
+    assert transformer.hm_bucket_weight.shape[1] == 1032
+
+
+def test_factorized_and_relation_tables_keep_sparse_active_row_gradients():
+    transformer = _tiny_transformer()
+    perspective = SimpleNamespace(
+        hm=_slice(), capture_pair=_slice(), king_blast_ep=_slice(), blast_ring=_slice()
+    )
+    main, psqt = transformer.forward(perspective, fake_quantize_weights=True)
+    (main.sum() + psqt.sum()).backward()
+
+    for parameter in (
+        transformer.hm_bucket_weight,
+        transformer.hm_virtual_weight,
+        transformer.capture_pair_weight,
+        transformer.king_blast_ep_weight,
+        transformer.blast_ring_weight,
+    ):
+        assert parameter.grad is not None
+        assert parameter.grad.is_sparse
+        assert parameter.grad.coalesce().indices().shape[1] == 1
+
+
+def test_mixed_feature_quantizers_use_i8_only_for_cp_and_ring():
+    values = torch.tensor([-200.0, -128.0 / 256.0, 127.0 / 256.0, 200.0])
+    i8 = fake_quantize_i8_feature(values)
+    i16 = fake_quantize_i16_feature(values)
+    assert i8.tolist() == pytest.approx([-0.5, -0.5, 127.0 / 256.0, 127.0 / 256.0])
+    assert i16[0] == pytest.approx(-128.0)
+    assert i16[-1] == pytest.approx(32767.0 / 256.0)
+
+
+def test_clip_weights_makes_mixed_tables_and_factor_sums_exportable():
+    model = _tiny_model()
+    transformer = model.feature_transformer
+    with torch.no_grad():
+        transformer.bias[0:2] = torch.tensor([1.0e9, -1.0e9])
+        transformer.capture_pair_weight[0, 0:2] = torch.tensor([1.0e9, -1.0e9])
+        transformer.king_blast_ep_weight[0, 0:2] = torch.tensor([1.0e9, -1.0e9])
+        transformer.blast_ring_weight[0, 0:2] = torch.tensor([1.0e9, -1.0e9])
+        transformer.hm_virtual_weight[0, 0:2] = torch.tensor([1.0e9, -1.0e9])
+        transformer.hm_bucket_weight[0, 0:2] = torch.tensor([1.0e9, -1.0e9])
+        transformer.hm_virtual_weight[0, 1024:1026] = torch.tensor([1.0e9, -1.0e9])
+        transformer.hm_bucket_weight[0, 1024:1026] = torch.tensor([1.0e9, -1.0e9])
+        model.network.fc0.factorized_linear.weight[0, 0:2] = torch.tensor(
+            [1.0e9, -1.0e9]
+        )
+        model.network.fc0.linear.weight[:, 0:2] = torch.tensor([1.0e9, -1.0e9])
+        model.network.fc0.factorized_linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
+        for bucket in range(8):
+            offset = bucket * 32
+            model.network.fc0.linear.bias[offset : offset + 2] = torch.tensor(
+                [1.0e30, -1.0e30]
+            )
+            model.network.fc1.linear.bias[offset : offset + 2] = torch.tensor(
+                [1.0e30, -1.0e30]
+            )
+        model.network.fc2.linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
+
+    model.clip_weights()
+
+    assert transformer.bias[0].item() == 32767.0 / FT_ONE
+    assert transformer.bias[1].item() == -32768.0 / FT_ONE
+    for table in (transformer.capture_pair_weight, transformer.blast_ring_weight):
+        assert table[0, 0].item() == 127.0 / FT_ONE
+        assert table[0, 1].item() == -128.0 / FT_ONE
+    assert transformer.king_blast_ep_weight[0, 0].item() == 32767.0 / FT_ONE
+    assert transformer.king_blast_ep_weight[0, 1].item() == -32768.0 / FT_ONE
+
+    hm_main = transformer.hm_bucket_weight[:, :1024] + transformer.hm_virtual_weight[:, :1024]
+    assert torch.all(hm_main >= -32768.0 / FT_ONE)
+    assert torch.all(hm_main <= 32767.0 / FT_ONE)
+    hm_psqt = transformer.hm_bucket_weight[:, 1024:] + transformer.hm_virtual_weight[:, 1024:]
+    assert torch.all(hm_psqt >= PSQT_EXPORT_MIN)
+    assert torch.all(hm_psqt <= PSQT_EXPORT_MAX)
+    scaled_psqt = torch.round(hm_psqt.to(torch.float64) * PSQT_WEIGHT_SCALE)
+    assert torch.all(scaled_psqt >= -(1 << 31))
+    assert torch.all(scaled_psqt <= (1 << 31) - 1)
+
+    fc0_factor = model.network.fc0.factorized_linear.weight
+    fc0_export = model.network.fc0.linear.weight + fc0_factor.repeat(8, 1)
+    fc0_limit = 127.0 / FC0_WEIGHT_SCALE
+    assert torch.all(fc0_factor >= -fc0_limit)
+    assert torch.all(fc0_factor <= fc0_limit)
+    assert torch.all(fc0_export >= -fc0_limit)
+    assert torch.all(fc0_export <= fc0_limit)
+
+    _assert_fc0_serializable_in_both_widths(model)
+    for dtype in (torch.float32, torch.float64):
+        fc0_bias = model.network.fc0.linear.bias.to(
+            dtype
+        ) + model.network.fc0.factorized_linear.bias.repeat(8).to(dtype)
+        assert torch.all(fc0_bias >= FC0_BIAS_EXPORT_MIN)
+        assert torch.all(fc0_bias <= FC0_BIAS_EXPORT_MAX)
+
+    bias_cases = (
+        (
+            model.network.fc1.linear.bias,
+            FC1_BIAS_SCALE,
+            FC1_BIAS_EXPORT_MIN,
+            FC1_BIAS_EXPORT_MAX,
+        ),
+        (
+            model.network.fc2.linear.bias,
+            FC2_BIAS_SCALE,
+            FC2_BIAS_EXPORT_MIN,
+            FC2_BIAS_EXPORT_MAX,
+        ),
+    )
+    for bias, scale, minimum, maximum in bias_cases:
+        assert torch.all(bias >= minimum)
+        assert torch.all(bias <= maximum)
+        for dtype in (torch.float32, torch.float64):
+            integers = torch.round(bias.to(dtype) * scale).to(torch.float64)
+            assert torch.all(integers >= -(1 << 31))
+            assert torch.all(integers <= (1 << 31) - 1)
+
+
+@pytest.mark.parametrize("scale", [FC0_BIAS_SCALE, FC1_BIAS_SCALE, FC2_BIAS_SCALE])
+def test_dense_bias_fake_quantizer_is_inward_i32_safe_for_extreme_float32(scale):
+    values = torch.tensor([-torch.finfo(torch.float32).max, torch.finfo(torch.float32).max])
+    quantized = fake_quantize_integer_bias(values, scale)
+    assert torch.all(torch.isfinite(quantized))
+    for dtype in (torch.float32, torch.float64):
+        integers = torch.round(quantized.to(dtype) * scale).to(torch.float64)
+        assert torch.all(integers >= -(1 << 31))
+        assert torch.all(integers <= (1 << 31) - 1)
+
+
+def test_fc0_opposite_sign_half_ulp_regressions_are_clipped_before_serialization():
+    model = _tiny_model()
+    with torch.no_grad():
+        # float32 coalescing rounds this exact safe sum outward to 2**31.
+        model.network.fc0.linear.bias[0] = 131072.0
+        model.network.fc0.factorized_linear.bias[0] = -1.0 / 256.0
+        # float32 hides this half-ulp, but float64 exposes -2147483776.
+        model.network.fc0.linear.bias[1] = -131072.015625
+        model.network.fc0.factorized_linear.bias[1] = 1.0 / 128.0
+
+    base = model.network.fc0.linear.bias
+    factor = model.network.fc0.factorized_linear.bias.repeat(8)
+    before32 = torch.round((base + factor) * FC0_BIAS_SCALE)
+    before64 = torch.round(
+        (base.to(torch.float64) + factor.to(torch.float64)) * FC0_BIAS_SCALE
+    )
+    assert before32[0].item() == 2147483648
+    assert before64[1].item() == -2147483776
+    with pytest.raises(OverflowError):
+        _fc0_serialized_integers(model, torch.float32)
+    with pytest.raises(OverflowError):
+        _fc0_serialized_integers(model, torch.float64)
+
+    model.clip_weights()
+    _assert_fc0_serializable_in_both_widths(model)
+
+
+def test_fc0_coordinated_clamp_fuzzes_nextafter_edges_in_both_widths():
+    model = _tiny_model()
+    generator = torch.Generator().manual_seed(0xA70C)
+    with torch.no_grad():
+        model.network.fc0.linear.bias.uniform_(-1.0e9, 1.0e9, generator=generator)
+        model.network.fc0.factorized_linear.bias.uniform_(
+            -1.0e9, 1.0e9, generator=generator
+        )
+        lower = torch.tensor(FC0_BIAS_EXPORT_MIN, dtype=torch.float32)
+        upper = torch.tensor(FC0_BIAS_EXPORT_MAX, dtype=torch.float32)
+        toward_negative = torch.tensor(float("-inf"), dtype=torch.float32)
+        toward_positive = torch.tensor(float("inf"), dtype=torch.float32)
+        edge_values = []
+        for edge in (lower, upper):
+            edge_values.extend(
+                (
+                    torch.nextafter(edge, toward_negative),
+                    edge,
+                    torch.nextafter(edge, toward_positive),
+                )
+            )
+        model.network.fc0.linear.bias[: len(edge_values)] = torch.stack(edge_values)
+        model.network.fc0.factorized_linear.bias[: len(edge_values)] = -torch.stack(
+            edge_values
+        )
+
+    model.clip_weights()
+    _assert_fc0_serializable_in_both_widths(model)
+
+
+@pytest.mark.parametrize("nonfinite", [float("nan"), float("inf"), float("-inf")])
+def test_clip_weights_rejects_nonfinite_dense_biases(nonfinite):
+    model = _tiny_model()
+    with torch.no_grad():
+        model.network.fc1.linear.bias[0] = nonfinite
+    with pytest.raises(FloatingPointError, match="non-finite"):
+        model.clip_weights()
+
+
+def test_psqt_fake_quantizer_stays_inside_i32_after_adversarial_float32_input():
+    values = torch.tensor([[-1.0e30, 1.0e30]], dtype=torch.float32)
+    quantized = fake_quantize_psqt_weight(values)
+    integers = torch.round(quantized.to(torch.float64) * PSQT_WEIGHT_SCALE)
+    assert torch.all(integers >= -(1 << 31))
+    assert torch.all(integers <= (1 << 31) - 1)
+
+
+def test_optimizer_step_clips_both_the_forward_boundary_and_persistent_state(monkeypatch):
+    class DummyModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.tensor([2.0]))
+            self.clip_calls = 0
+
+        @torch.no_grad()
+        def clip_weights(self):
+            self.clip_calls += 1
+            self.weight.clamp_(-1.0, 1.0)
+
+    model = DummyModel()
+    optimizer = torch.optim.SGD(model.parameters(), lr=10.0)
+    monkeypatch.setattr(
+        v3_training,
+        "batch_loss",
+        lambda candidate, batch, lambda_=0.5: candidate.weight.square().sum(),
+    )
+    reported = optimizer_step(model, optimizer, object())
+    assert reported == pytest.approx(1.0)
+    assert model.clip_calls == 2
+    assert model.weight.item() == -1.0
+
+
+def test_optimizer_step_keeps_all_dense_biases_i32_safe_before_and_after_update(monkeypatch):
+    model = _tiny_model()
+    with torch.no_grad():
+        model.network.fc0.linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
+        model.network.fc0.factorized_linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
+        model.network.fc0.linear.bias[2:4] = torch.tensor(
+            [131072.0, -131072.015625]
+        )
+        model.network.fc0.factorized_linear.bias[2:4] = torch.tensor(
+            [-1.0 / 256.0, 1.0 / 128.0]
+        )
+        model.network.fc1.linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
+        model.network.fc2.linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
+
+    raw_base = model.network.fc0.linear.bias
+    raw_factor = model.network.fc0.factorized_linear.bias.repeat(8)
+    assert torch.round((raw_base + raw_factor) * FC0_BIAS_SCALE)[2].item() == 2147483648
+    assert torch.round(
+        (raw_base.to(torch.float64) + raw_factor.to(torch.float64)) * FC0_BIAS_SCALE
+    )[3].item() == -2147483776
+
+    observed_forward = []
+
+    def assert_exportable(candidate):
+        _assert_fc0_serializable_in_both_widths(candidate)
+        cases = (
+            (candidate.network.fc1.linear.bias, FC1_BIAS_SCALE),
+            (candidate.network.fc2.linear.bias, FC2_BIAS_SCALE),
+        )
+        for bias, scale in cases:
+            integers = torch.round(bias.to(torch.float64) * scale)
+            assert torch.all(integers >= -(1 << 31))
+            assert torch.all(integers <= (1 << 31) - 1)
+
+    def adversarial_loss(candidate, batch, lambda_=0.5):
+        assert_exportable(candidate)
+        observed_forward.append(True)
+        positive = (
+            candidate.network.fc0.linear.bias[0]
+            + candidate.network.fc0.factorized_linear.bias[0]
+            + candidate.network.fc1.linear.bias[0]
+            + candidate.network.fc2.linear.bias[0]
+        )
+        negative = (
+            candidate.network.fc0.linear.bias[1]
+            + candidate.network.fc0.factorized_linear.bias[1]
+            + candidate.network.fc1.linear.bias[1]
+            + candidate.network.fc2.linear.bias[1]
+        )
+        return positive - negative
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=1.0e9)
+    monkeypatch.setattr(v3_training, "batch_loss", adversarial_loss)
+    optimizer_step(model, optimizer, object())
+
+    assert observed_forward == [True]
+    assert_exportable(model)
+    merged = model.network.fc0.linear.bias + model.network.fc0.factorized_linear.bias.repeat(8)
+    assert merged[0] < 0.0 and merged[1] > 0.0
+    assert model.network.fc1.linear.bias[0] < 0.0
+    assert model.network.fc1.linear.bias[1] > 0.0
+    assert model.network.fc2.linear.bias[0] < 0.0
+    assert model.network.fc2.linear.bias[1] > 0.0
+
+
+def test_sfnnv15_dense_tail_shapes_and_short_skip_are_frozen():
+    stacks = AtomicV3LayerStacks()
+    assert tuple(stacks.fc0.linear.weight.shape) == (8 * 32, 1024)
+    assert tuple(stacks.fc0.factorized_linear.weight.shape) == (32, 1024)
+    assert tuple(stacks.fc1.linear.weight.shape) == (8 * 32, 64)
+    assert tuple(stacks.fc2.linear.weight.shape) == (8, 128)
+
+    with torch.no_grad():
+        for parameter in stacks.parameters():
+            parameter.zero_()
+        for bucket in range(8):
+            stacks.fc0.linear.bias[bucket * 32 + 30] = 3.0
+            stacks.fc0.linear.bias[bucket * 32 + 31] = 1.0
+    output = stacks(
+        torch.zeros((3, 1024)),
+        torch.tensor([0, 3, 7]),
+        fake_quantize_activations=False,
+        fake_quantize_weights=False,
+    )
+    torch.testing.assert_close(output, torch.full((3, 1), 2.0))
+
+
+def test_signed_psqt_half_uses_cpp_truncation_and_keeps_ste_gradient():
+    raw = torch.tensor([[-3.0], [-1.0], [1.0], [3.0]], requires_grad=True)
+    output = fake_quantize_psqt_output(raw / (2.0 * PSQT_WEIGHT_SCALE))
+    torch.testing.assert_close(
+        output * PSQT_WEIGHT_SCALE,
+        torch.tensor([[-1.0], [0.0], [0.0], [1.0]]),
+    )
+    output.sum().backward()
+    assert torch.all(torch.isfinite(raw.grad))
+
+
+def test_atomic_loss_rejects_ambiguous_shapes_and_nonfinite_is_not_hidden():
+    with pytest.raises(ValueError, match="equal shape"):
+        atomic_loss(torch.zeros((2, 1)), torch.zeros((1, 1)), torch.zeros((2, 1)))
+    value = atomic_loss(
+        torch.tensor([[float("nan")]]), torch.tensor([[0.5]]), torch.tensor([[0.0]])
+    )
+    assert torch.isnan(value)
+
+
+def test_production_shape_cpu_one_step_is_finite_and_deterministic():
+    # The fixture loader checks train and validation independently before the
+    # production-size model is allocated.
+    fixture = load_canonical_fixture()
+    assert fixture.batch("train").batch_size == 2
+    assert fixture.batch("validation").batch_size == 1
+
+    first = deterministic_cpu_one_step(seed=20260716)
+    second = deterministic_cpu_one_step(seed=20260716)
+
+    assert first == second
+    assert first.train_loss_after < first.train_loss_before
+    assert first.validation_loss_before >= 0.0
+    assert first.validation_loss_after >= 0.0
+    assert len(first.parameter_sha256) == 64
+
+
+@pytest.mark.parametrize("learning_rate", [float("nan"), float("inf"), -float("inf"), 0.0])
+def test_core_optimizer_rejects_nonfinite_or_nonpositive_learning_rate(learning_rate):
+    model = _tiny_model()
+    with pytest.raises(ValueError, match="finite and positive"):
+        create_core_optimizer(model, learning_rate)
+
+
+@pytest.mark.parametrize("learning_rate", [True, "0.001"])
+def test_core_optimizer_rejects_non_real_learning_rate(learning_rate):
+    model = _tiny_model()
+    with pytest.raises(TypeError, match="real number"):
+        create_core_optimizer(model, learning_rate)
+
+
+@pytest.mark.parametrize("seed", [True, 1.5, "1"])
+def test_deterministic_step_rejects_non_integer_seed_before_allocating(seed):
+    with pytest.raises(TypeError, match="seed must be an integer"):
+        deterministic_cpu_one_step(seed=seed)
+
+
+@pytest.mark.parametrize("seed", [-1, 1 << 64])
+def test_deterministic_step_rejects_seed_outside_nonnegative_uint64(seed):
+    with pytest.raises(ValueError, match="non-negative uint64"):
+        deterministic_cpu_one_step(seed=seed)

--- a/tests/test_atomic_v3_model_training.py
+++ b/tests/test_atomic_v3_model_training.py
@@ -6,7 +6,11 @@ import torch
 import atomic_v3.training as v3_training
 from atomic_v3.dataset import SparseSliceBatch, load_canonical_fixture
 from atomic_v3.dense import AtomicV3LayerStacks, fake_quantize_integer_bias
-from atomic_v3.model import AtomicNNUEV3, AtomicV3FeatureTransformer
+from atomic_v3.model import (
+    AtomicNNUEV3,
+    AtomicV3FeatureTransformer,
+    _clip_factorized_i32_sums_,
+)
 from atomic_v3.quantization import (
     FC0_BIAS_EXPORT_MAX,
     FC0_BIAS_EXPORT_MIN,
@@ -19,6 +23,8 @@ from atomic_v3.quantization import (
     FC2_BIAS_EXPORT_MIN,
     FC2_BIAS_SCALE,
     FT_ONE,
+    INT32_MAX,
+    INT32_MIN,
     PSQT_EXPORT_MAX,
     PSQT_EXPORT_MIN,
     PSQT_WEIGHT_SCALE,
@@ -62,13 +68,67 @@ def _tiny_model():
     return model
 
 
-def _fc0_serialized_integers(model, dtype):
-    base = model.network.fc0.linear.bias.to(dtype)
-    factor = model.network.fc0.factorized_linear.bias.repeat(8).to(dtype)
-    rounded = torch.round((base + factor) * FC0_BIAS_SCALE).to(torch.float64)
-    if torch.any(rounded < -(1 << 31)) or torch.any(rounded > (1 << 31) - 1):
-        raise OverflowError("FC0 bias is outside signed-i32 wire range")
+def _tiny_forward_batch(device):
+    active = SparseSliceBatch(
+        torch.tensor([[0]], dtype=torch.int32, device=device),
+        torch.tensor([[1.0]], dtype=torch.float32, device=device),
+    )
+    perspective = SimpleNamespace(
+        hm=active,
+        capture_pair=active,
+        king_blast_ep=active,
+        blast_ring=active,
+    )
+    return SimpleNamespace(
+        white=perspective,
+        black=perspective,
+        side_to_move_white=torch.ones((1, 1), dtype=torch.float32, device=device),
+        bucket_indices=torch.zeros(1, dtype=torch.long, device=device),
+    )
+
+
+def _rng_snapshot():
+    cpu = torch.random.get_rng_state().clone()
+    cuda = (
+        tuple(state.clone() for state in torch.cuda.get_rng_state_all())
+        if torch.cuda.is_initialized()
+        else None
+    )
+    return cpu, cuda
+
+
+def _assert_rng_snapshot_equal(expected):
+    cpu, cuda = _rng_snapshot()
+    assert torch.equal(cpu, expected[0])
+    if expected[1] is None:
+        assert cuda is None
+    else:
+        assert cuda is not None and len(cuda) == len(expected[1])
+        assert all(torch.equal(actual, saved) for actual, saved in zip(cuda, expected[1]))
+
+
+def _factorized_i32_serialized_integers(base, factor, dtype, scale, label):
+    """Future serializer boundary: range-check before the signed-i32 cast."""
+
+    merged = base.to(dtype) + factor.to(dtype)
+    # The mixed-width serializer widens the persisted sum before applying the
+    # integer scale; it must reject overflow before any signed cast.
+    rounded = torch.round(merged.to(torch.float64) * float(scale))
+    if not torch.all(torch.isfinite(rounded)) or torch.any(rounded < INT32_MIN) or torch.any(
+        rounded > INT32_MAX
+    ):
+        raise OverflowError(f"{label} is outside signed-i32 wire range")
     return rounded.to(torch.int64)
+
+
+def _fc0_serialized_integers(model, dtype):
+    return _factorized_i32_serialized_integers(
+        model.network.fc0.linear.bias,
+        model.network.fc0.factorized_linear.bias.repeat(8),
+        dtype,
+        FC0_BIAS_SCALE,
+        "FC0 bias",
+    )
 
 
 def _assert_fc0_serializable_in_both_widths(model):
@@ -76,6 +136,27 @@ def _assert_fc0_serializable_in_both_widths(model):
         integers = _fc0_serialized_integers(model, dtype)
         assert torch.all(integers >= -(1 << 31))
         assert torch.all(integers <= (1 << 31) - 1)
+
+
+def _hm_psqt_serialized_integers(transformer, dtype):
+    base = transformer.hm_bucket_weight[:, 1024:]
+    factor = transformer.hm_virtual_weight[:, 1024:]
+    if base.shape[0] % factor.shape[0] != 0:
+        raise ValueError("test HM factor shapes are inconsistent")
+    return _factorized_i32_serialized_integers(
+        base,
+        factor.repeat(base.shape[0] // factor.shape[0], 1),
+        dtype,
+        PSQT_WEIGHT_SCALE,
+        "HM PSQT weight",
+    )
+
+
+def _assert_hm_psqt_serializable_in_both_widths(transformer):
+    for dtype in (torch.float32, torch.float64):
+        integers = _hm_psqt_serialized_integers(transformer, dtype)
+        assert torch.all(integers >= INT32_MIN)
+        assert torch.all(integers <= INT32_MAX)
 
 
 def test_v3_composed_transformer_factorizes_hm_and_gives_relations_no_psqt():
@@ -178,6 +259,7 @@ def test_clip_weights_makes_mixed_tables_and_factor_sums_exportable():
     scaled_psqt = torch.round(hm_psqt.to(torch.float64) * PSQT_WEIGHT_SCALE)
     assert torch.all(scaled_psqt >= -(1 << 31))
     assert torch.all(scaled_psqt <= (1 << 31) - 1)
+    _assert_hm_psqt_serializable_in_both_widths(transformer)
 
     fc0_factor = model.network.fc0.factorized_linear.weight
     fc0_export = model.network.fc0.linear.weight + fc0_factor.repeat(8, 1)
@@ -286,6 +368,84 @@ def test_fc0_coordinated_clamp_fuzzes_nextafter_edges_in_both_widths():
     _assert_fc0_serializable_in_both_widths(model)
 
 
+def test_hm_psqt_opposite_sign_rounding_regressions_are_clipped_before_serialization():
+    transformer = _tiny_transformer()
+    with torch.no_grad():
+        # Both sums are just outside the signed-i32 domain after a float32
+        # limit subtraction has rounded the persisted base away from zero.
+        transformer.hm_bucket_weight[0, 1024:1026] = torch.tensor(
+            [345969.1875, -407320.25]
+        )
+        transformer.hm_virtual_weight[0, 1024:1026] = torch.tensor(
+            [-122272.96875, 183624.03125]
+        )
+
+    base = transformer.hm_bucket_weight[:, 1024:]
+    factor = transformer.hm_virtual_weight[:, 1024:]
+    before32 = torch.round((base + factor) * PSQT_WEIGHT_SCALE)
+    before64 = torch.round(
+        (base.to(torch.float64) + factor.to(torch.float64)) * PSQT_WEIGHT_SCALE
+    )
+    assert before32[0, 0].item() == 2147483648
+    assert before64[0, 0].item() == 2147483700
+    assert before64[0, 1].item() == -2147483700
+    with pytest.raises(OverflowError):
+        _hm_psqt_serialized_integers(transformer, torch.float32)
+    with pytest.raises(OverflowError):
+        _hm_psqt_serialized_integers(transformer, torch.float64)
+
+    transformer.clip_weights()
+    _assert_hm_psqt_serializable_in_both_widths(transformer)
+
+
+def test_hm_psqt_coordinated_clamp_randomized_persistent_wire_sweep():
+    generator = torch.Generator().manual_seed(0xA70C0003)
+    base = torch.nn.Parameter(torch.empty((32768, 8), dtype=torch.float32))
+    factor = torch.nn.Parameter(torch.empty((32768, 8), dtype=torch.float32))
+    with torch.no_grad():
+        base.uniform_(-1.0e9, 1.0e9, generator=generator)
+        factor.uniform_(PSQT_EXPORT_MIN, PSQT_EXPORT_MAX, generator=generator)
+        base[0, :2] = torch.tensor([345969.1875, -407320.25])
+        factor[0, :2] = torch.tensor([-122272.96875, 183624.03125])
+
+    original_device = base.device
+    original_dtype = base.dtype
+    _clip_factorized_i32_sums_(
+        base,
+        factor,
+        scale=PSQT_WEIGHT_SCALE,
+        minimum=PSQT_EXPORT_MIN,
+        maximum=PSQT_EXPORT_MAX,
+        label="HM PSQT randomized test",
+    )
+
+    assert base.device == factor.device == original_device
+    assert base.dtype == factor.dtype == original_dtype
+    assert base.requires_grad and factor.requires_grad
+    assert base.grad_fn is None and factor.grad_fn is None
+    for dtype in (torch.float32, torch.float64):
+        integers = _factorized_i32_serialized_integers(
+            base, factor, dtype, PSQT_WEIGHT_SCALE, "HM PSQT randomized test"
+        )
+        assert torch.all(integers >= INT32_MIN)
+        assert torch.all(integers <= INT32_MAX)
+
+
+@pytest.mark.parametrize("parameter", ["bucket", "factor"])
+@pytest.mark.parametrize("nonfinite", [float("nan"), float("inf"), float("-inf")])
+def test_hm_psqt_factorized_clamp_rejects_nonfinite_operands(parameter, nonfinite):
+    transformer = _tiny_transformer()
+    with torch.no_grad():
+        target = (
+            transformer.hm_bucket_weight
+            if parameter == "bucket"
+            else transformer.hm_virtual_weight
+        )
+        target[0, 1024] = nonfinite
+    with pytest.raises(FloatingPointError, match="HM PSQT factor is non-finite"):
+        transformer.clip_weights()
+
+
 @pytest.mark.parametrize("nonfinite", [float("nan"), float("inf"), float("-inf")])
 def test_clip_weights_rejects_nonfinite_dense_biases(nonfinite):
     model = _tiny_model()
@@ -328,9 +488,15 @@ def test_optimizer_step_clips_both_the_forward_boundary_and_persistent_state(mon
     assert model.weight.item() == -1.0
 
 
-def test_optimizer_step_keeps_all_dense_biases_i32_safe_before_and_after_update(monkeypatch):
+def test_optimizer_step_keeps_all_factorized_i32_sums_safe_before_and_after_update(monkeypatch):
     model = _tiny_model()
     with torch.no_grad():
+        model.feature_transformer.hm_bucket_weight[0, 1024:1026] = torch.tensor(
+            [345969.1875, -407320.25]
+        )
+        model.feature_transformer.hm_virtual_weight[0, 1024:1026] = torch.tensor(
+            [-122272.96875, 183624.03125]
+        )
         model.network.fc0.linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
         model.network.fc0.factorized_linear.bias[0:2] = torch.tensor([1.0e30, -1.0e30])
         model.network.fc0.linear.bias[2:4] = torch.tensor(
@@ -352,6 +518,7 @@ def test_optimizer_step_keeps_all_dense_biases_i32_safe_before_and_after_update(
     observed_forward = []
 
     def assert_exportable(candidate):
+        _assert_hm_psqt_serializable_in_both_widths(candidate.feature_transformer)
         _assert_fc0_serializable_in_both_widths(candidate)
         cases = (
             (candidate.network.fc1.linear.bias, FC1_BIAS_SCALE),
@@ -391,6 +558,55 @@ def test_optimizer_step_keeps_all_dense_biases_i32_safe_before_and_after_update(
     assert model.network.fc1.linear.bias[1] > 0.0
     assert model.network.fc2.linear.bias[0] < 0.0
     assert model.network.fc2.linear.bias[1] > 0.0
+
+
+@pytest.mark.cuda_gate
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Atomic V3 CUDA smoke needs a GPU")
+def test_atomic_v3_cuda_clamp_forward_backward_and_optimizer_edges(monkeypatch):
+    device = torch.device("cuda")
+    model = _tiny_model().to(device)
+    batch = _tiny_forward_batch(device)
+    with torch.no_grad():
+        model.feature_transformer.hm_bucket_weight[0, 1024:1026] = torch.tensor(
+            [345969.1875, -407320.25], device=device
+        )
+        model.feature_transformer.hm_virtual_weight[0, 1024:1026] = torch.tensor(
+            [-122272.96875, 183624.03125], device=device
+        )
+        model.network.fc0.linear.bias[0:2] = torch.tensor(
+            [131072.0, -131072.015625], device=device
+        )
+        model.network.fc0.factorized_linear.bias[0:2] = torch.tensor(
+            [-1.0 / 256.0, 1.0 / 128.0], device=device
+        )
+
+    observed = []
+
+    def cuda_loss(candidate, ignored_batch, lambda_=0.5):
+        _assert_hm_psqt_serializable_in_both_widths(candidate.feature_transformer)
+        _assert_fc0_serializable_in_both_widths(candidate)
+        output = candidate(batch, validate=False)
+        assert output.device.type == "cuda"
+        assert torch.all(torch.isfinite(output))
+        observed.append(True)
+        return output.square().mean()
+
+    monkeypatch.setattr(v3_training, "batch_loss", cuda_loss)
+    optimizer = create_core_optimizer(model, learning_rate=1.0e-3)
+    reported = optimizer_step(model, optimizer, batch)
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(torch.tensor(reported))
+    assert observed == [True]
+    _assert_hm_psqt_serializable_in_both_widths(model.feature_transformer)
+    _assert_fc0_serializable_in_both_widths(model)
+    assert model.feature_transformer.hm_bucket_weight.grad is not None
+    assert model.feature_transformer.hm_bucket_weight.grad.is_sparse
+    assert torch.all(
+        torch.isfinite(model.feature_transformer.hm_bucket_weight.grad.coalesce().values())
+    )
+    del optimizer, batch, model
+    torch.cuda.empty_cache()
 
 
 def test_sfnnv15_dense_tail_shapes_and_short_skip_are_frozen():
@@ -442,14 +658,85 @@ def test_production_shape_cpu_one_step_is_finite_and_deterministic():
     assert fixture.batch("train").batch_size == 2
     assert fixture.batch("validation").batch_size == 1
 
+    rng_before = _rng_snapshot()
     first = deterministic_cpu_one_step(seed=20260716)
+    _assert_rng_snapshot_equal(rng_before)
     second = deterministic_cpu_one_step(seed=20260716)
+    _assert_rng_snapshot_equal(rng_before)
 
     assert first == second
     assert first.train_loss_after < first.train_loss_before
     assert first.validation_loss_before >= 0.0
     assert first.validation_loss_after >= 0.0
     assert len(first.parameter_sha256) == 64
+
+
+def test_deterministic_cpu_step_restores_cpu_rng_when_fixture_raises(monkeypatch):
+    rng_before = _rng_snapshot()
+    monkeypatch.setattr(
+        v3_training,
+        "load_canonical_fixture",
+        lambda: (_ for _ in ()).throw(RuntimeError("fixture failure")),
+    )
+    with pytest.raises(RuntimeError, match="fixture failure"):
+        deterministic_cpu_one_step(seed=20260716)
+    _assert_rng_snapshot_equal(rng_before)
+
+
+def test_deterministic_cpu_step_restores_warn_only_mode_when_fixture_raises(monkeypatch):
+    threads_before = torch.get_num_threads()
+    deterministic_before = torch.are_deterministic_algorithms_enabled()
+    warn_only_before = torch.is_deterministic_algorithms_warn_only_enabled()
+    monkeypatch.setattr(
+        v3_training,
+        "load_canonical_fixture",
+        lambda: (_ for _ in ()).throw(RuntimeError("fixture failure")),
+    )
+    try:
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        with pytest.raises(RuntimeError, match="fixture failure"):
+            deterministic_cpu_one_step(seed=20260716)
+        assert torch.are_deterministic_algorithms_enabled()
+        assert torch.is_deterministic_algorithms_warn_only_enabled()
+        assert torch.get_num_threads() == threads_before
+    finally:
+        torch.use_deterministic_algorithms(
+            deterministic_before, warn_only=warn_only_before
+        )
+
+
+def test_deterministic_cpu_step_does_not_initialize_cuda_for_healthcheck(monkeypatch):
+    cpu_before = torch.random.get_rng_state().clone()
+    monkeypatch.setattr(torch.cuda, "is_initialized", lambda: False)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("CPU healthcheck touched an uninitialized CUDA RNG")
+
+    monkeypatch.setattr(torch.cuda, "get_rng_state_all", forbidden)
+    monkeypatch.setattr(torch.cuda, "set_rng_state_all", forbidden)
+    monkeypatch.setattr(
+        v3_training,
+        "load_canonical_fixture",
+        lambda: (_ for _ in ()).throw(RuntimeError("fixture failure")),
+    )
+    with pytest.raises(RuntimeError, match="fixture failure"):
+        deterministic_cpu_one_step(seed=20260716)
+    assert torch.equal(torch.random.get_rng_state(), cpu_before)
+
+
+@pytest.mark.cuda_gate
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA RNG restore needs a GPU")
+def test_deterministic_cpu_step_restores_initialized_cuda_rng_on_exception(monkeypatch):
+    torch.cuda.manual_seed_all(0xA70C0003)
+    rng_before = _rng_snapshot()
+    monkeypatch.setattr(
+        v3_training,
+        "load_canonical_fixture",
+        lambda: (_ for _ in ()).throw(RuntimeError("fixture failure")),
+    )
+    with pytest.raises(RuntimeError, match="fixture failure"):
+        deterministic_cpu_one_step(seed=20260716)
+    _assert_rng_snapshot_equal(rng_before)
 
 
 @pytest.mark.parametrize("learning_rate", [float("nan"), float("inf"), -float("inf"), 0.0])


### PR DESCRIPTION
## Summary

Implements the H9.3l-j trainer core for the frozen AtomicNNUEV3 wire-v1 architecture, isolated under atomic_v3/ so it does not alter the legacy trainer CLI, generic feature registration, or AtomicNNUEV2 dispatch.

- freezes the engine/trainer contract, descriptor hashes, dimensions and exact index mappings for HalfKAv2AtomicHM, CapturePair, KingBlastEP and BlastRing;
- implements the mixed-precision feature transformer, HM 12-to-11 factorization, eight-stack SFNNv15 dense tail, fake quantization, sparse gradients and controlled optimizer boundary;
- adds a strict authenticated Atomic BIN V2 campaign/receipt boundary with ordered train/validation roles, immutable manifest bytes, symlink/reparse rejection and canonical fixture validation;
- validates reconstructed positions, active-row counts, kings, occupancy, scores and outcomes before allocating the model;
- adds a deterministic production-shape CPU one-step healthcheck without selecting a production optimizer or training schedule;
- extends CI for CPython 3.9-3.12 import compatibility and an opt-in required CUDA/CuPy gate.

## Persistent-state and isolation hardening

The final audit found and closes three boundary defects before publication:

1. Factorized HM PSQT operands with opposite signs could individually appear clamped while float32 cancellation rounded the serialized sum to +2147483648 or below signed-i32. HM PSQT and FC0 factorized i32 values are now coalesced in float64, persisted as coordinated float32 operands, corrected inward in the actual sum ULP domain, and verified against all supported wire-rounding views before any integer cast.
2. Authenticated campaign bytes were followed by Path.resolve(), leaving a post-authentication provenance/parent TOCTOU. Authenticated reads now return an immutable snapshot containing the frozen absolute lexical label, descriptor identity, digest and bytes; consumers never re-resolve that label as authority.
3. The deterministic CPU healthcheck altered caller RNG state and could lose PyTorch's independent deterministic warn_only mode. It now restores the CPU RNG, every already initialized CUDA RNG, deterministic mode plus warn_only, and thread count on success and exceptions, without initializing CUDA.

The repository actionlint configuration also declares the custom cuda self-hosted runner label used by the opt-in gate.

## Compatibility and impact

- Keeps the legacy and AtomicNNUEV2 backends isolated and unchanged.
- Pins the V3 contract to Atomic-Stockfish commit dde43fc08fb2bd45eec09d3dbe9f6d06845eeb24.
- Preserves CPython 3.9 through 3.12 compatibility.
- Makes every persistent optimizer boundary export-safe for mixed i16/i8 tables, HM PSQT, and dense signed-i32 biases.
- Provides authenticated, disjoint train/validation input to the future controlled training runner.

## Deliberate milestone limits

This PR proves the trainer graph, indexing, factorization, dataset boundary, forward/loss path, clipping, sparse gradients and deterministic CPU/CUDA healthchecks. Checkpoint/network serialization, final environment binding, the production optimizer/schedule, controlled execution evidence and the first real training run remain H9.3l-k or later work.

## Validation

- Atomic V3 suite: **105 passed**
- Full Python suite: **218 passed**
- Required real CUDA gate (ATOMIC_REQUIRE_CUDA_TESTS=1): **2 passed**
- MSVC Release native gate: **1/1 CTest passed**
- python -m compileall -q atomic_v3
- Real CPython 3.9.13 and 3.10.11: all 8 atomic_v3 modules compiled/imported
- PyYAML BaseLoader workflow/config parse
- actionlint 1.7.12
- git diff --check against atomic
- Added-line/full-tree secret scans: 0 findings
- Independent final audit: no open P0/P1/P2 findings

## Commits

- 0b8432c1932564fac6e2a38e978cf0fe1af76505 - isolated AtomicNNUEV3 trainer core
- 6f57b1df6e51c8f806cd7e1e62aa47af3e4b622e - persistent-state and isolation hardening